### PR TITLE
# Add /servicestatus endpoint to allow automated status monitoring.

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,43 @@
 class HomeController < ApplicationController
+  skip_before_action :authenticate_user!, only: [:servicestatus]
+
   def index; end
+
+  # Display basic service status in HTML or JSON
+  # For automatic status detection, the service is working correctly if the resulting string has
+  # a key 'status' and a value starting 'OK'.
+  # Also allows minimal admin actions (e.g. restarting webapps for logged in developers
+  # or while the service is idle)
+  def servicestatus
+    webapp_status = if ENV['RAILS_MASTER_KEY'].blank?
+                      'OK: no RAILS_MASTER_KEY configured'
+                    else
+                      'OK (using RAILS_MASTER_KEY)'
+                    end
+    revision_and_timestamp = lambda do |dir|
+      fname = File.join(dir, 'REVISION') # for capistrano deployments
+      File.exist?(fname) ? [File.read(fname).chomp, File.mtime(fname).getlocal] : ['Unknown', nil]
+    end
+    running_revision, running_revision_time = revision_and_timestamp.call(Rails.root)
+    current_revision, current_revision_time = \
+      revision_and_timestamp.call(Rails.root.join('../../current'))
+    status = { 'status' => webapp_status,
+               'running_revision' => running_revision,
+               'running_revision_time' => running_revision_time,
+               'current_revision' => current_revision,
+               'current_revision_time' => current_revision_time,
+               'system_stack' => Mbis.stack,
+               'system_start_time' => ::TIME_PROCESS_STARTED.getlocal,
+               'system_time' => Time.now.getlocal,
+               'logged_in' => user_signed_in?,
+               'database_migration_latest' => ActiveRecord::Migrator.current_version }
+    respond_to do |format|
+      format.json do
+        render json: status
+      end
+      format.html do
+        @status = status
+      end
+    end
+  end
 end

--- a/app/views/home/servicestatus.html.erb
+++ b/app/views/home/servicestatus.html.erb
@@ -1,0 +1,22 @@
+<div class="col-xs-6 col-xs-offset-3">
+    <h1>Data Management System service status</h1>
+
+  <%= bootstrap_panel_tag '' do %>
+    <table class="table table-hover table-condensed table-striped">
+      <thead>
+        <tr>
+          <th>Key</th>
+          <th>Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @status.each do |k, v| %>
+          <tr>
+            <td><code><%= k %></code></td>
+            <td><code><%= v %></code></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,5 @@
+TIME_PROCESS_STARTED = Time.now
+
 require_relative 'boot'
 
 require 'rails/all'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,7 @@ Rails.application.routes.draw do
     end
   end
 
+  get :servicestatus, to: 'home#servicestatus'
   resources :home, only: [:index]
 
   resources :terms_and_conditions, only: [:index, :create]


### PR DESCRIPTION
This adds /servicestatus and /servicestatus.json endpoints. These are useful for conveniently checking the service is OK, monitoring the deployed revision and checking uptime.