### PR TITLE
# Avoid spurious deprecation warnings with capistrano 2 and bundler 2.x

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,3 +1,6 @@
+# Avoid spurious deprecation warning on STDERR with capistrano 2 and bundler 2.x
+set :bundle_cmd, 'BUNDLE_SILENCE_DEPRECATIONS=true bundle'
+
 require 'bundler/capistrano'
 require 'ndr_dev_support/capistrano/ndr_model'
 require 'delayed/recipes'


### PR DESCRIPTION
This silences a bundler deprecation warning on deployments. This ensures that successful deployments should have no messages on STDERR.