### PR TITLE
Fix for variantpathclass assignment

### DIFF
--- a/lib/import/brca/providers/newcastle/newcastle_handler.rb
+++ b/lib/import/brca/providers/newcastle/newcastle_handler.rb
@@ -23,7 +23,6 @@ module Import
                                             PASS_THROUGH_FIELDS,
                                             FIELD_NAME_MAPPINGS)
             add_organisationcode_testresult(genotype)
-            add_variantpathclass(genotype, record)
             process_test_scope(genotype, record)
             process_test_status(genotype, record)
             final_results = process_variant_records(genotype, record)
@@ -117,17 +116,14 @@ module Import
             gene = get_gene(record)
             genotype.add_gene(gene)
             variant = get_variant(record)
-            if positive_rec?(record)
+            if positive_rec?(record) || gene.present?
               add_fs_negative_gene(genotype, genotypes)
-              process_variants(genotype, variant)
+              process_variants(genotype, variant) if positive_rec?(record)
+              add_variantpathclass(genotype, record)
               genotypes.append(genotype)
-            elsif gene.present? # for other status records
-              genotypes.append(genotype)
-              add_fs_negative_gene(genotype, genotypes)
             else
               process_null_gene_rec(genotype, genotypes)
             end
-
             genotypes
           end
 
@@ -160,6 +156,7 @@ module Import
             genotype.add_gene(get_gene(record))
             variant = get_variant(record)
             process_variants(genotype, variant) if positive_rec?(record)
+            add_variantpathclass(genotype, record)
             genotypes.append(genotype)
             genotypes
           end

--- a/lib/import/colorectal/providers/newcastle/newcastle_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/newcastle/newcastle_handler_colorectal.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'possibly'
 
 module Import
@@ -23,7 +22,6 @@ module Import
             add_organisationcode_testresult(genocolorectal)
             add_test_scope(genocolorectal, record)
             add_test_type(genocolorectal, record)
-            add_variant_class(genocolorectal, record)
             add_test_status(genocolorectal, record)
             res = process_variant_records(genocolorectal, record) # Added by Francesco
             res.each { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
@@ -135,6 +133,7 @@ module Import
             else # for other status null gene record
               process_null_gene_rec(genocolorectal, genocolorectals)
             end
+            add_variant_class(genocolorectal, record)
           end
 
           def add_fs_negative_genes(gene, genocolorectal, genocolorectals, _record)
@@ -164,6 +163,7 @@ module Import
             gene = get_gene(record)
             genocolorectal.add_gene_colorectal(gene)
             process_variants(genocolorectal, variant) if positive_rec?(genocolorectal)
+            add_variant_class(genocolorectal, record)
             genocolorectals.append(genocolorectal)
           end
 

--- a/test/lib/import/brca/providers/newcastle/newcastle_handler_test.rb
+++ b/test/lib/import/brca/providers/newcastle/newcastle_handler_test.rb
@@ -294,12 +294,12 @@ class NewcastleHandlerTest < ActiveSupport::TestCase
     genotypes = @handler.process_variant_records(nmd_withmutation_genotype, nmd_withmutation_record)
     assert_equal 'Full screen BRCA1 and BRCA2', genotypes[0].attribute_map['genetictestscope']
     assert_equal 'Full screen BRCA1 and BRCA2', genotypes[1].attribute_map['genetictestscope']
-    assert_equal 4, genotypes[0].attribute_map['teststatus']
-    assert_equal 1, genotypes[1].attribute_map['teststatus']
-    assert_equal 7, genotypes[0].attribute_map['gene']
-    assert_equal 8, genotypes[1].attribute_map['gene']
-    assert_nil genotypes[0].attribute_map['codingdnasequencechange']
-    assert_nil genotypes[1].attribute_map['proteinimpact']
+    assert_equal 4, genotypes[1].attribute_map['teststatus']
+    assert_equal 1, genotypes[0].attribute_map['teststatus']
+    assert_equal 7, genotypes[1].attribute_map['gene']
+    assert_equal 8, genotypes[0].attribute_map['gene']
+    assert_nil genotypes[1].attribute_map['codingdnasequencechange']
+    assert_nil genotypes[0].attribute_map['proteinimpact']
   end
 
   test 'process_fs_rec_only_with_no_result_status' do
@@ -441,6 +441,15 @@ class NewcastleHandlerTest < ActiveSupport::TestCase
     assert_equal 1, genotypes[0].attribute_map['teststatus']
     assert_nil genotypes[0].attribute_map['gene']
     assert_nil genotypes[0].attribute_map['codingdnasequencechange']
+  end
+
+  test 'variantpathclass assignes to only gene in raw[gene]' do
+    @handler.process_test_scope(@genotype, @record)
+    genotypes = @handler.process_variant_records(@genotype, @record)
+    assert_nil genotypes[0].attribute_map['variantpathclass']
+    assert_equal 8, genotypes[0].attribute_map['gene']
+    assert_equal 3, genotypes[1].attribute_map['variantpathclass']
+    assert_equal 7, genotypes[1].attribute_map['gene']
   end
 
   private

--- a/test/lib/import/colorectal/providers/newcastle/newcastle_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/newcastle/newcastle_handler_colorectal_test.rb
@@ -174,6 +174,21 @@ class NewcastleHandlerColorectalTest < ActiveSupport::TestCase
     end
   end
 
+  test 'variantpathclass assignes to only gene in raw[gene]' do
+    @handler.add_test_scope(@genotype, @record)
+    genotypes = @handler.process_variant_records(@genotype, @record)
+    assert_nil genotypes[0].attribute_map['variantpathclass']
+    assert_equal 2744, genotypes[0].attribute_map['gene']
+    assert_nil genotypes[1].attribute_map['variantpathclass']
+    assert_equal 2808, genotypes[1].attribute_map['gene']
+    assert_nil genotypes[2].attribute_map['variantpathclass']
+    assert_equal 3394, genotypes[2].attribute_map['gene']
+    assert_nil genotypes[3].attribute_map['variantpathclass']
+    assert_equal 1432, genotypes[3].attribute_map['gene']
+    assert_equal 5, genotypes[4].attribute_map['variantpathclass']
+    assert_equal 2804, genotypes[4].attribute_map['gene']
+  end
+
   private
 
   def clinical_json


### PR DESCRIPTION
## What?

This is to assign variantpath class only to the gene listed in raw['gene'] and not all genes of the record.

## Why?

These changes are to resolve planio ticket #https://ncr.plan.io/issues/34051

## Testing?

Added new test
