### PR TITLE
Oxford CRC assign positive test status

### DIFF
--- a/lib/import/helpers/colorectal/providers/rth/constants.rb
+++ b/lib/import/helpers/colorectal/providers/rth/constants.rb
@@ -43,7 +43,7 @@ module Import
             BRCA2)/xi
             # rubocop:disable Lint/MixedRegexpCaptureTypes
             PROTEIN_REGEX            = /p\.\[(?<impact>(.*?))\]|p\..+/i
-            CDNA_REGEX               = /c\.\[?(?<cdna>[0-9]+.+[a-z])\]?/i
+            CDNA_REGEX               = /c\.\[?(?<cdna>[-0-9?.>_+a-z]+)\]?/i
             GENOMICCHANGE_REGEX      = /Chr(?<chromosome>\d+)\.hg(?<genome_build>\d+)
                                        :g\.(?<effect>.+)/xi
             VAR_PATH_CLASS_MAP = {
@@ -53,7 +53,7 @@ module Import
               '10' => '',
               'n/a' => ''
             }.freeze
-            CHROMOSOME_VARIANT_REGEX = /(?<chromvar>del|ins|dup)/i
+            CHROMOSOME_VARIANT_REGEX = /(?<chromvar>del|ins|dup|inv)/i
             # rubocop:enable Lint/MixedRegexpCaptureTypes
           end
         end

--- a/test/lib/import/colorectal/providers/oxford/oxford_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/oxford/oxford_handler_colorectal_test.rb
@@ -134,6 +134,18 @@ class OxfordHandlerColorectalTest < ActiveSupport::TestCase
     assert_equal 4, @genotype.attribute_map['variantpathclass']
   end
 
+  test 'assign positive test status to records with exon inversion and c.?' do
+    genotypes = []
+    inv_record = build_raw_record('pseudo_id1' => 'bob')
+    inv_record.raw_fields['codingdnasequencechange'] = 'Exons 1-7 inversion'
+    @handler.process_cdna_change(inv_record, @genotype, genotypes)
+    assert_equal 2, @genotype.attribute_map['teststatus']
+    pos_rec = build_raw_record('pseudo_id1' => 'bob')
+    pos_rec.raw_fields['codingdnasequencechange'] = 'c.?'
+    @handler.process_cdna_change(pos_rec, @genotype, genotypes)
+    assert_equal 2, @genotype.attribute_map['teststatus']
+  end
+
   private
 
   def clinical_json


### PR DESCRIPTION
## What?

I have amended regex of chromomosomal and codingdnasequence to allow _c.?_ and _Inversion of exon_ to be captured as positive genotype.

## Why?

Fiona after analysts suggestions has asked that for Oxford colorectal , above cases should be marked as positive. 
More information can be found in planio ticket #34166

## How?

Changes in the regex.

## Testing?

Have added test case for above scenario.