### PR TITLE
Update out-of-bundle gems for deployments.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -166,7 +166,7 @@ after 'deploy:start',   'delayed_job:start'
 after 'deploy:restart', 'delayed_job:restart'
 
 before 'ndr_dev_support:update_out_of_bundle_gems' do
-  set :out_of_bundle_gems, webapp_deployment ? %w[puma rack nio4r] : %w[]
+  set :out_of_bundle_gems, webapp_deployment ? %w[puma puma-daemon rack nio4r] : %w[]
 end
 
 namespace :ndr_dev_support do


### PR DESCRIPTION
This fixes an omission from PR #29, by adding `puma-daemon` to the list of out-of-bundle gems for deployments.