### PR TITLE
Status changes as per varpathclass

### DIFF
--- a/lib/import/helpers/brca/providers/rvj/rvj_constants.rb
+++ b/lib/import/helpers/brca/providers/rvj/rvj_constants.rb
@@ -15,8 +15,8 @@ module Import
             CDNA_REGEX = /c\.(?<cdna>[0-9]+[^\s|^, ]+)/
             PROTEIN_REGEX = /p.\(?(?<impact>.*)\)?/
 
-            TESTSTATUS_MAP = { 'Benign' => :negative,
-                               'Likely Benign' => :negative,
+            TESTSTATUS_MAP = { 'Benign' => 10,
+                               'Likely Benign' => 10,
                                'Deleterious' => :positive,
                                'Likely Deleterious' => :positive,
                                'Likely Pathogenic' => :positive,

--- a/test/lib/import/brca/providers/bristol/bristol_handler_test.rb
+++ b/test/lib/import/brca/providers/bristol/bristol_handler_test.rb
@@ -34,7 +34,9 @@ class BristolHandlerTest < ActiveSupport::TestCase
     res = @handler.process_gene(@genotype, normal_record)
     assert_equal 2, res.size
     assert_equal 1, res[0].attribute_map['teststatus']
-    assert_equal 1, res[1].attribute_map['teststatus']
+    assert_equal 7, res[0].attribute_map['gene']
+    assert_equal 10, res[1].attribute_map['teststatus']
+    assert_equal 8, res[1].attribute_map['gene']
   end
 
   test 'process_protein_impact' do


### PR DESCRIPTION
## What?
Test status for ‘raw:variantpathclass’ = ‘Benign’ or ‘Likely Benign’, should be 10.

## Testing
Tests updated and denominators QA approved by Fiona
