### PR TITLE
Feature/35204/newcastle importer

### DIFF
--- a/lib/import/colorectal/providers/newcastle/newcastle_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/newcastle/newcastle_handler_colorectal.rb
@@ -99,7 +99,7 @@ module Import
             if gene.present? && variant.present? && pathogenic?(record)
               genocolorectal.add_status(2)
             elsif gene.present? && variant.present? && non_pathogenic?(record)
-              genotype.add_status(10)
+              genocolorectal.add_status(10)
             elsif gene.present? && variant.blank?
               genocolorectal.add_status(4)
             elsif teststatus.present? && teststatus.scan(/fail/i).size.positive?

--- a/lib/import/helpers/brca/providers/rtd/rtd_constants.rb
+++ b/lib/import/helpers/brca/providers/rtd/rtd_constants.rb
@@ -48,8 +48,7 @@ module Import
                                      consultantcode
                                      servicereportidentifier].freeze
 
-
-            NO_MUTATION_DETECTED_CODES= ['nmd']
+            NO_MUTATION_DETECTED_CODES = ['nmd'].freeze
 
             NON_PATHEGENIC_CODES = ['likely benign',
                                     'benign',
@@ -64,9 +63,9 @@ module Import
             # rubocop:disable Lint/MixedRegexpCaptureTypes
             PROTEIN_REGEX = /p\.\((?<impact>.+)\)|
                             \(p\.(?<impact>[A-Za-z]+.+)\)|
-                            p\.(?<impact>[A-Za-z]+.+)/ix.freeze # Added by Francesco
+                            p\.(?<impact>[A-Za-z]+.+)/ix # Added by Francesco
             BRCA_REGEX = /(?<brca>BRCA1|BRCA2|PALB2|ATM|CHEK2|TP53|MLH1|CDH1|
-                                  MSH2|MSH6|PMS2|STK11|PTEN|BRIP1|NBN|RAD51C|RAD51D)/ix.freeze
+                                  MSH2|MSH6|PMS2|STK11|PTEN|BRIP1|NBN|RAD51C|RAD51D)/ix
             CDNA_REGEX = /c\.\*?(?<cdna>
                                  [0-9]+[a-z]+>[a-z]+|
                                  [0-9]+_[0-9]+[ACGTdelinsup]+|
@@ -76,7 +75,7 @@ module Import
                                  [0-9]+[a-z]+|
                                  [0-9]+[+>_-][0-9]+[+>_-][0-9]+[+>_-][0-9]+[ACGTdelinsup]+|
                                  [0-9]+[+>_-][0-9]+[+>_-][0-9]+[ACGTdelinsup]+|
-                                 [0-9]+.[0-9]+[a-z]+>[a-z]+)\s?/ix.freeze
+                                 [0-9]+.[0-9]+[a-z]+>[a-z]+)\s?/ix
 
             EXON_VARIANT_REGEX = /(?<variant>del|dup|ins).+ex(?<on>on)?(?<s>s)?\s
                                   (?<exons>[0-9]+(?<dgs>-[0-9]+)?)|
@@ -90,7 +89,7 @@ module Import
                                 ex(?<on>on)?(?<s>s)?\s(?<exons>[0-9]+(?<dgs>\sto\s[0-9]+)?)\s
                                 (?<variant>del|dup|ins)|
                                 x(?<exons>[0-9]+-?[0-9]+)\s?(?<variant>del|dup|ins)|
-                                x(?<exons>[0-9]+-?[0-9]?)\s?(?<variant>del|dup|ins)/ix.freeze
+                                x(?<exons>[0-9]+-?[0-9]?)\s?(?<variant>del|dup|ins)/ix
             # rubocop:enable Lint/MixedRegexpCaptureTypes
           end
         end

--- a/lib/import/helpers/brca/providers/rtd/rtd_constants.rb
+++ b/lib/import/helpers/brca/providers/rtd/rtd_constants.rb
@@ -48,8 +48,10 @@ module Import
                                      consultantcode
                                      servicereportidentifier].freeze
 
-            NON_PATHEGENIC_CODES = ['nmd',
-                                    'likely benign',
+
+            NO_MUTATION_DETECTED_CODES= ['nmd']
+
+            NON_PATHEGENIC_CODES = ['likely benign',
                                     'benign',
                                     'non-pathological variant'].freeze
 

--- a/lib/import/helpers/colorectal/providers/rtd/rtd_constants.rb
+++ b/lib/import/helpers/colorectal/providers/rtd/rtd_constants.rb
@@ -57,7 +57,7 @@ module Import
               'tp53' => %w[TP53]
             }.freeze
 
-            NO_MUTATION_DETECTED_CODES= ['nmd']
+            NO_MUTATION_DETECTED_CODES = ['nmd'].freeze
 
             NON_PATHEGENIC_CODES = ['likely benign',
                                     'benign',

--- a/lib/import/helpers/colorectal/providers/rtd/rtd_constants.rb
+++ b/lib/import/helpers/colorectal/providers/rtd/rtd_constants.rb
@@ -57,8 +57,9 @@ module Import
               'tp53' => %w[TP53]
             }.freeze
 
-            NON_PATHEGENIC_CODES = ['nmd',
-                                    'likely benign',
+            NO_MUTATION_DETECTED_CODES= ['nmd']
+
+            NON_PATHEGENIC_CODES = ['likely benign',
                                     'benign',
                                     'non-pathological variant'].freeze
             # rubocop:disable Lint/MixedRegexpCaptureTypes

--- a/test/lib/import/brca/providers/newcastle/newcastle_handler_test.rb
+++ b/test/lib/import/brca/providers/newcastle/newcastle_handler_test.rb
@@ -189,7 +189,7 @@ class NewcastleHandlerTest < ActiveSupport::TestCase
     assert_nil nostatus_genotype.attribute_map['codingdnasequencechange']
   end
 
-  test 'process_noscope_with_gene_mutation' do
+  test 'process_noscope_with_non_pathological_gene_mutation' do
     noscope_genemutation_record = build_raw_record('pseudo_id1' => 'bob')
     noscope_genemutation_record.raw_fields['moleculartestingtype'] = 'Unknown / other'
     noscope_genemutation_record.raw_fields['service category'] = 'B'
@@ -203,7 +203,47 @@ class NewcastleHandlerTest < ActiveSupport::TestCase
     @handler.process_test_status(noscope_genotype, noscope_genemutation_record)
     genotypes = @handler.process_variant_records(noscope_genotype, noscope_genemutation_record)
     assert_equal 'Unable to assign BRCA genetictestscope', noscope_genotype.attribute_map['genetictestscope']
-    assert_equal 1, genotypes[0].attribute_map['teststatus']
+    assert_equal 10, genotypes[0].attribute_map['teststatus']
+    assert_equal 8, genotypes[0].attribute_map['gene']
+    assert_nil genotypes[0].attribute_map['codingdnasequencechange']
+  end
+
+
+  test 'process_noscope_with_likely_benign_gene_mutation' do
+    noscope_genemutation_record = build_raw_record('pseudo_id1' => 'bob')
+    noscope_genemutation_record.raw_fields['moleculartestingtype'] = 'Unknown / other'
+    noscope_genemutation_record.raw_fields['service category'] = 'B'
+    noscope_genemutation_record.raw_fields['investigation code'] = 'BRCA'
+    noscope_genemutation_record.raw_fields['gene'] = 'BRCA2'
+    noscope_genemutation_record.raw_fields['genotype'] = 'c.8850G>T'
+    noscope_genemutation_record.raw_fields['variantpathclass'] = 'likely benign'
+    noscope_genemutation_record.raw_fields['teststatus'] = 'het'
+    noscope_genotype = Import::Brca::Core::GenotypeBrca.new(noscope_genemutation_record)
+    @handler.process_test_scope(noscope_genotype, noscope_genemutation_record)
+    @handler.process_test_status(noscope_genotype, noscope_genemutation_record)
+    genotypes = @handler.process_variant_records(noscope_genotype, noscope_genemutation_record)
+    assert_equal 'Unable to assign BRCA genetictestscope', noscope_genotype.attribute_map['genetictestscope']
+    assert_equal 10, genotypes[0].attribute_map['teststatus']
+  end
+
+
+
+
+  test 'process_noscope_with_benign_gene_mutation' do
+    noscope_genemutation_record = build_raw_record('pseudo_id1' => 'bob')
+    noscope_genemutation_record.raw_fields['moleculartestingtype'] = 'Unknown / other'
+    noscope_genemutation_record.raw_fields['service category'] = 'B'
+    noscope_genemutation_record.raw_fields['investigation code'] = 'BRCA'
+    noscope_genemutation_record.raw_fields['gene'] = 'BRCA2'
+    noscope_genemutation_record.raw_fields['genotype'] = 'c.8850G>T'
+    noscope_genemutation_record.raw_fields['variantpathclass'] = 'benign'
+    noscope_genemutation_record.raw_fields['teststatus'] = 'het'
+    noscope_genotype = Import::Brca::Core::GenotypeBrca.new(noscope_genemutation_record)
+    @handler.process_test_scope(noscope_genotype, noscope_genemutation_record)
+    @handler.process_test_status(noscope_genotype, noscope_genemutation_record)
+    genotypes = @handler.process_variant_records(noscope_genotype, noscope_genemutation_record)
+    assert_equal 'Unable to assign BRCA genetictestscope', noscope_genotype.attribute_map['genetictestscope']
+    assert_equal 10, genotypes[0].attribute_map['teststatus']
     assert_equal 8, genotypes[0].attribute_map['gene']
     assert_nil genotypes[0].attribute_map['codingdnasequencechange']
   end

--- a/test/lib/import/brca/providers/newcastle/newcastle_handler_test.rb
+++ b/test/lib/import/brca/providers/newcastle/newcastle_handler_test.rb
@@ -208,7 +208,6 @@ class NewcastleHandlerTest < ActiveSupport::TestCase
     assert_nil genotypes[0].attribute_map['codingdnasequencechange']
   end
 
-
   test 'process_noscope_with_likely_benign_gene_mutation' do
     noscope_genemutation_record = build_raw_record('pseudo_id1' => 'bob')
     noscope_genemutation_record.raw_fields['moleculartestingtype'] = 'Unknown / other'
@@ -225,9 +224,6 @@ class NewcastleHandlerTest < ActiveSupport::TestCase
     assert_equal 'Unable to assign BRCA genetictestscope', noscope_genotype.attribute_map['genetictestscope']
     assert_equal 10, genotypes[0].attribute_map['teststatus']
   end
-
-
-
 
   test 'process_noscope_with_benign_gene_mutation' do
     noscope_genemutation_record = build_raw_record('pseudo_id1' => 'bob')

--- a/test/lib/import/brca/providers/newcastle/newcastle_handler_test.rb
+++ b/test/lib/import/brca/providers/newcastle/newcastle_handler_test.rb
@@ -189,56 +189,56 @@ class NewcastleHandlerTest < ActiveSupport::TestCase
     assert_nil nostatus_genotype.attribute_map['codingdnasequencechange']
   end
 
-  test 'process_noscope_with_non_pathological_gene_mutation' do
-    noscope_genemutation_record = build_raw_record('pseudo_id1' => 'bob')
-    noscope_genemutation_record.raw_fields['moleculartestingtype'] = 'Unknown / other'
-    noscope_genemutation_record.raw_fields['service category'] = 'B'
-    noscope_genemutation_record.raw_fields['investigation code'] = 'BRCA'
-    noscope_genemutation_record.raw_fields['gene'] = 'BRCA2'
-    noscope_genemutation_record.raw_fields['genotype'] = 'c.8850G>T'
-    noscope_genemutation_record.raw_fields['variantpathclass'] = 'non-pathological variant'
-    noscope_genemutation_record.raw_fields['teststatus'] = 'het'
-    noscope_genotype = Import::Brca::Core::GenotypeBrca.new(noscope_genemutation_record)
-    @handler.process_test_scope(noscope_genotype, noscope_genemutation_record)
-    @handler.process_test_status(noscope_genotype, noscope_genemutation_record)
-    genotypes = @handler.process_variant_records(noscope_genotype, noscope_genemutation_record)
-    assert_equal 'Unable to assign BRCA genetictestscope', noscope_genotype.attribute_map['genetictestscope']
+  test 'process_non_pathological_gene_mutation_record' do
+    non_pathological_record = build_raw_record('pseudo_id1' => 'bob')
+    non_pathological_record.raw_fields['moleculartestingtype'] = 'Unknown / other'
+    non_pathological_record.raw_fields['service category'] = 'B'
+    non_pathological_record.raw_fields['investigation code'] = 'BRCA'
+    non_pathological_record.raw_fields['gene'] = 'BRCA2'
+    non_pathological_record.raw_fields['genotype'] = 'c.8850G>T'
+    non_pathological_record.raw_fields['variantpathclass'] = 'non-pathological variant'
+    non_pathological_record.raw_fields['teststatus'] = 'het'
+    non_pathological_genotype = Import::Brca::Core::GenotypeBrca.new(non_pathological_record)
+    @handler.process_test_scope(non_pathological_genotype, non_pathological_record)
+    @handler.process_test_status(non_pathological_genotype, non_pathological_record)
+    genotypes = @handler.process_variant_records(non_pathological_genotype, non_pathological_record)
+    assert_equal 'Unable to assign BRCA genetictestscope', non_pathological_genotype.attribute_map['genetictestscope']
     assert_equal 10, genotypes[0].attribute_map['teststatus']
     assert_equal 8, genotypes[0].attribute_map['gene']
     assert_nil genotypes[0].attribute_map['codingdnasequencechange']
   end
 
-  test 'process_noscope_with_likely_benign_gene_mutation' do
-    noscope_genemutation_record = build_raw_record('pseudo_id1' => 'bob')
-    noscope_genemutation_record.raw_fields['moleculartestingtype'] = 'Unknown / other'
-    noscope_genemutation_record.raw_fields['service category'] = 'B'
-    noscope_genemutation_record.raw_fields['investigation code'] = 'BRCA'
-    noscope_genemutation_record.raw_fields['gene'] = 'BRCA2'
-    noscope_genemutation_record.raw_fields['genotype'] = 'c.8850G>T'
-    noscope_genemutation_record.raw_fields['variantpathclass'] = 'likely benign'
-    noscope_genemutation_record.raw_fields['teststatus'] = 'het'
-    noscope_genotype = Import::Brca::Core::GenotypeBrca.new(noscope_genemutation_record)
-    @handler.process_test_scope(noscope_genotype, noscope_genemutation_record)
-    @handler.process_test_status(noscope_genotype, noscope_genemutation_record)
-    genotypes = @handler.process_variant_records(noscope_genotype, noscope_genemutation_record)
-    assert_equal 'Unable to assign BRCA genetictestscope', noscope_genotype.attribute_map['genetictestscope']
+  test 'process_likely_benign_record' do
+    likely_benign_record = build_raw_record('pseudo_id1' => 'bob')
+    likely_benign_record.raw_fields['moleculartestingtype'] = 'Unknown / other'
+    likely_benign_record.raw_fields['service category'] = 'B'
+    likely_benign_record.raw_fields['investigation code'] = 'BRCA'
+    likely_benign_record.raw_fields['gene'] = 'BRCA2'
+    likely_benign_record.raw_fields['genotype'] = 'c.8850G>T'
+    likely_benign_record.raw_fields['variantpathclass'] = 'likely benign'
+    likely_benign_record.raw_fields['teststatus'] = 'het'
+    likely_benign_genotype = Import::Brca::Core::GenotypeBrca.new(likely_benign_record)
+    @handler.process_test_scope(likely_benign_genotype, likely_benign_record)
+    @handler.process_test_status(likely_benign_genotype, likely_benign_record)
+    genotypes = @handler.process_variant_records(likely_benign_genotype, likely_benign_record)
+    assert_equal 'Unable to assign BRCA genetictestscope', likely_benign_genotype.attribute_map['genetictestscope']
     assert_equal 10, genotypes[0].attribute_map['teststatus']
   end
 
-  test 'process_noscope_with_benign_gene_mutation' do
-    noscope_genemutation_record = build_raw_record('pseudo_id1' => 'bob')
-    noscope_genemutation_record.raw_fields['moleculartestingtype'] = 'Unknown / other'
-    noscope_genemutation_record.raw_fields['service category'] = 'B'
-    noscope_genemutation_record.raw_fields['investigation code'] = 'BRCA'
-    noscope_genemutation_record.raw_fields['gene'] = 'BRCA2'
-    noscope_genemutation_record.raw_fields['genotype'] = 'c.8850G>T'
-    noscope_genemutation_record.raw_fields['variantpathclass'] = 'benign'
-    noscope_genemutation_record.raw_fields['teststatus'] = 'het'
-    noscope_genotype = Import::Brca::Core::GenotypeBrca.new(noscope_genemutation_record)
-    @handler.process_test_scope(noscope_genotype, noscope_genemutation_record)
-    @handler.process_test_status(noscope_genotype, noscope_genemutation_record)
-    genotypes = @handler.process_variant_records(noscope_genotype, noscope_genemutation_record)
-    assert_equal 'Unable to assign BRCA genetictestscope', noscope_genotype.attribute_map['genetictestscope']
+  test 'process_benign_record' do
+    benign_record = build_raw_record('pseudo_id1' => 'bob')
+    benign_record.raw_fields['moleculartestingtype'] = 'Unknown / other'
+    benign_record.raw_fields['service category'] = 'B'
+    benign_record.raw_fields['investigation code'] = 'BRCA'
+    benign_record.raw_fields['gene'] = 'BRCA2'
+    benign_record.raw_fields['genotype'] = 'c.8850G>T'
+    benign_record.raw_fields['variantpathclass'] = 'benign'
+    benign_record.raw_fields['teststatus'] = 'het'
+    benign_genotype = Import::Brca::Core::GenotypeBrca.new(benign_record)
+    @handler.process_test_scope(benign_genotype, benign_record)
+    @handler.process_test_status(benign_genotype, benign_record)
+    genotypes = @handler.process_variant_records(benign_genotype, benign_record)
+    assert_equal 'Unable to assign BRCA genetictestscope', benign_genotype.attribute_map['genetictestscope']
     assert_equal 10, genotypes[0].attribute_map['teststatus']
     assert_equal 8, genotypes[0].attribute_map['gene']
     assert_nil genotypes[0].attribute_map['codingdnasequencechange']

--- a/test/lib/import/colorectal/providers/newcastle/newcastle_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/newcastle/newcastle_handler_colorectal_test.rb
@@ -15,7 +15,8 @@ class NewcastleHandlerColorectalTest < ActiveSupport::TestCase
     @handler.add_test_status(@genotype, positive_record)
     assert_equal 2, @genotype.attribute_map['teststatus']
     fail_record = build_raw_record('pseudo_id1' => 'bob')
-    fail_record.raw_fields['variantpathclass'] = 'benign'
+    fail_record.raw_fields['gene'] = ''
+    fail_record.raw_fields['variantpathclass'] = ''
     fail_record.raw_fields['teststatus'] = 'fail'
     @handler.add_test_status(@genotype, fail_record)
     assert_equal 9, @genotype.attribute_map['teststatus']
@@ -25,6 +26,24 @@ class NewcastleHandlerColorectalTest < ActiveSupport::TestCase
     unknown_record.raw_fields['variantpathclass'] = 'nmd'
     @handler.add_test_status(@genotype, unknown_record)
     assert_equal 4, @genotype.attribute_map['teststatus']
+    benign_record = build_raw_record('pseudo_id1' => 'bob')
+    benign_record.raw_fields['gene'] = 'APC'
+    benign_record.raw_fields['genotype'] = 'het'
+    benign_record.raw_fields['variantpathclass'] = 'benign'
+    @handler.add_test_status(@genotype, benign_record)
+    assert_equal 10, @genotype.attribute_map['teststatus']
+    likely_benign_record = build_raw_record('pseudo_id1' => 'bob')
+    likely_benign_record.raw_fields['gene'] = 'APC'
+    likely_benign_record.raw_fields['genotype'] = 'het'
+    likely_benign_record.raw_fields['variantpathclass'] = 'likely benign'
+    @handler.add_test_status(@genotype, likely_benign_record)
+    assert_equal 10, @genotype.attribute_map['teststatus']
+    non_pathogenic_record = build_raw_record('pseudo_id1' => 'bob')
+    non_pathogenic_record.raw_fields['gene'] = 'APC'
+    non_pathogenic_record.raw_fields['genotype'] = 'het'
+    non_pathogenic_record.raw_fields['variantpathclass'] = 'non-pathological variant'
+    @handler.add_test_status(@genotype, non_pathogenic_record)
+    assert_equal 10, @genotype.attribute_map['teststatus']
   end
 
   test 'add_test_scope' do


### PR DESCRIPTION
Functionality to add test status of 10 to benign, likely benign and non-pathological variants. Unittests have been updated and run ok for the Newcastle importer. Couple of integration issues when running all unittests- these have been flagged to @shilpigoeldev. Variant counts QA has been completed and checked.