### PR TITLE
Feature/35366/variantlocation

### DIFF
--- a/lib/import/brca/providers/royal_marsden/royal_marsden_handler.rb
+++ b/lib/import/brca/providers/royal_marsden/royal_marsden_handler.rb
@@ -25,13 +25,14 @@ module Import
 
           TEST_TYPE_MAP = { 'affected' => :diagnostic,
                             'unaffected' => :predictive }.freeze
-
+          # rubocop:disable Lint/MixedRegexpCaptureTypes
           CDNA_REGEX_PROT = /c\.(?<cdna>.+)(?=(?<separtors>_|;.)p\.(?<impact>.+))/i.freeze
           CDNA_REGEX_NOPROT = /c\.(?<cdna>.+)/i.freeze
           DEL_DUP_REGEX = /(?<deldup>Deletion|Duplication)\s(ex|exon)s?\s?
                            (?<exon>\d+([a-z -]+\d+)?)|
                            (exon|ex)s?\s?(?<exon>\d+([a-z -]+\d+)?)\s?
                            (?<deldup>Deletion|Duplication)/ix
+          # rubocop:enable Lint/MixedRegexpCaptureTypes
 
           def initialize(batch)
             @failed_genotype_counter = 0

--- a/lib/import/brca/providers/royal_marsden/royal_marsden_handler.rb
+++ b/lib/import/brca/providers/royal_marsden/royal_marsden_handler.rb
@@ -28,9 +28,10 @@ module Import
 
           CDNA_REGEX_PROT = /c\.(?<cdna>.+)(?=(?<separtors>_|;.)p\.(?<impact>.+))/i.freeze
           CDNA_REGEX_NOPROT = /c\.(?<cdna>.+)/i.freeze
-          DEL_DUP_REGEX = /(?<deldup>Deletion|Duplication)\sexon(?<s>s)?\s(?<exon>\d+(?<d>-\d+)?)|
-                           exon(?<s>s)?\s(?<exon>\d+(?<d>-\d+)?)
-                           \s(?<deldup>Deletion|Duplication)/ix.freeze
+          DEL_DUP_REGEX = /(?<deldup>Deletion|Duplication)\s(ex|exon)s?\s?
+                           (?<exon>\d+([a-z -]+\d+)?)|
+                           (exon|ex)s?\s?(?<exon>\d+([a-z -]+\d+)?)\s?
+                           (?<deldup>Deletion|Duplication)/ix
 
           def initialize(batch)
             @failed_genotype_counter = 0

--- a/lib/import/brca/providers/salisbury/salisbury_handler.rb
+++ b/lib/import/brca/providers/salisbury/salisbury_handler.rb
@@ -78,7 +78,7 @@ module Import
             return unless variant.scan(EXON_VARIANT_REGEX).size.positive?
 
             genotype.add_exon_location($LAST_MATCH_INFO[:exons])
-            genotype.add_variant_type($LAST_MATCH_INFO[:mutationtype]&.downcase)
+            genotype.add_variant_type($LAST_MATCH_INFO[:mutationtype].to_s)
             @logger.debug "SUCCESSFUL exon variant parse for: #{variant}"
           end
 

--- a/lib/import/brca/scripts/bash/Import_all_brca_interactive.sh
+++ b/lib/import/brca/scripts/bash/Import_all_brca_interactive.sh
@@ -170,7 +170,6 @@ MBIS=$1
 PROV='RPY'
 IFS=$'\n'
 for x in $(find  $DIRPATH/$FILEPATH -type f -name "*.pseudo" -path "*/$PROV/*" \
-! -name "*TRIP13*" \
 ! -name "8f98012da7c87b12ca1221dd3dc9d34a10952720_05.2019_BRCA only TGL data_cleaned2.xlsx.pseudo")
 do
 IFS="$OIFS"

--- a/lib/import/database_wrappers/genetic_sequence_variant.rb
+++ b/lib/import/database_wrappers/genetic_sequence_variant.rb
@@ -11,20 +11,19 @@ module Import
       def initialize(genotype)
         @representative_genotype = genotype
         @field_names = Pseudo::GeneticSequenceVariant.column_names -
-         # %w[geneticsequencevariantid genetictestresultid raw_record]
-        %w[geneticsequencevariantid
-          genetic_test_result_id
-          humangenomebuild
-          referencetranscriptid
-          genomicchange
-          clinvarid
-          cosmicid
-          variantlocation
-          variantgenotype
-          variantallelefrequency
-          variantreport
-          raw_record
-          age]
+                       # %w[geneticsequencevariantid genetictestresultid raw_record]
+                       %w[geneticsequencevariantid
+                          genetic_test_result_id
+                          humangenomebuild
+                          referencetranscriptid
+                          genomicchange
+                          clinvarid
+                          cosmicid
+                          variantgenotype
+                          variantallelefrequency
+                          variantreport
+                          raw_record
+                          age]
       end
 
       # Should not produce a variant record unless there actually is a variant

--- a/lib/import/germline/genotype.rb
+++ b/lib/import/germline/genotype.rb
@@ -225,23 +225,18 @@ module Import
       end
 
       def add_variant_type(location)
-        return nil unless location.is_a? String
+        return nil unless location.is_a?(String)
 
-        location_downcase = location&.downcase
-        @attribute_map['sequencevarianttype'] = if location_downcase.include?('delins') ||
-                                                   location_downcase.include?('indel')
-                                                  6
-                                                elsif location_downcase.include? 'dup'
-                                                  4
-                                                elsif location_downcase.include? 'del'
-                                                  3
-                                                elsif location_downcase.include? '>'
-                                                  1
-                                                elsif location_downcase.include? 'ins'
-                                                  2
-                                                else
-                                                  10
-                                                end
+        type = case location.downcase
+               when /delins|indel/ then 6
+               when /dup/ then 4
+               when /del/ then 3
+               when />/ then 1
+               when /ins/ then 2
+               else 10
+               end
+
+        @attribute_map['sequencevarianttype'] = type
       end
 
       def add_exon_location(location_string)

--- a/lib/import/germline/genotype.rb
+++ b/lib/import/germline/genotype.rb
@@ -227,18 +227,20 @@ module Import
       def add_variant_type(location)
         return nil unless location.is_a? String
 
-        @attribute_map['sequencevarianttype'] = if location.include?('delins') ||
-                                                   location.include?('indel')
+        location_downcase = location&.downcase
+        @attribute_map['sequencevarianttype'] = if location_downcase.include?('delins') ||
+                                                   location_downcase.include?('indel')
                                                   6
-                                                elsif location.include? 'dup'
+                                                elsif location_downcase.include? 'dup'
                                                   4
-                                                elsif location.include? 'del'
+                                                elsif location_downcase.include? 'del'
                                                   3
-                                                elsif location.include? '>'
+                                                elsif location_downcase.include? '>'
                                                   1
-                                                elsif location.include? 'ins'
+                                                elsif location_downcase.include? 'ins'
                                                   2
-                                                else 10
+                                                else
+                                                  10
                                                 end
       end
 

--- a/lib/import/helpers/brca/providers/rcu/rcu_constants.rb
+++ b/lib/import/helpers/brca/providers/rcu/rcu_constants.rb
@@ -193,16 +193,12 @@ module Import
             PROTEIN_REGEX = /p\.(\[\()?(?<impact>.([a-z]+[0-9]+[a-z]+([^[:alnum:]][0-9]+)?)|
                                    ([a-z]+[0-9]+[^[:alnum:]]))(\)\])?/ix.freeze
 
-            EXON_VARIANT_REGEX = /(?<ex>(?<zygosity>het|homo)[a-z ]+)?
+            EXON_VARIANT_REGEX = /((?<zygosity>het|homo)[a-z ]+)?
                                   (?<mutationtype>deletion|duplication|duplicated)\s?
-                                  ([a-z 0-9]+ (exon|exons)\s
-                                  (?<exons>[0-9]+([a-z -]+[0-9]+)?))|
-                                  (?<ex>(?<zygosity>het|homo)[a-z ]+)?
-                                  (?<ex>(?<nm>exon|exons)\s(?<exons>[0-9]+([a-z -]+[0-9]+)?))
-                                  ([a-z ]+
-                                  (?<mutationtype>deletion|duplication|duplicated))?/ix.freeze
-
-            DEL_DUP_REGEX = /(?:\W*(del)(?:etion|[^\W])?)|(?:\W*(dup)(?:lication|[^\W])?)/i.freeze
+                                  ([a-z 0-9]+(?<nm>exon|exons)\s(?<exons>[0-9]+((to|and|-|\s)+[0-9]+)?))|
+                                  ((?<zygosity>het|homo)[a-z ]+)?
+                                  (?<nm>exon|exons)\s(?<exons>[0-9]+((to|and|-|\s)+[0-9]+)?)
+                                  ([a-z ]+(?<mutationtype>deletion|duplication|duplicated))?/ix
 
             NORMAL_VAR_REGEX = %r{(?<not>no|not)[a-z /]+
                                   (?<det>detect|report|detet|mutation)+}ix.freeze

--- a/lib/import/helpers/brca/providers/rcu/rcu_constants.rb
+++ b/lib/import/helpers/brca/providers/rcu/rcu_constants.rb
@@ -18,10 +18,10 @@ module Import
               'BRCA1 and 2 gene analysis' => :process_scope_gene_analysis,
               'Breast & Ovarian cancer panel' => :process_scope_ovarian_panel,
               'Breast Ovarian & Colorectal cancer panel' => :process_scope_colo_ovarian_panel,
-              'R205 :: Inherited breast cancer'\
-              ' (without ovarian cancer) at very high familial risk' => :process_scope_r205,
-              'R206 :: Inherited breast cancer'\
-              ' and ovarian cancer at high familial risk levels' => :process_scope_r206,
+              'R205 :: Inherited breast cancer ' \
+              '(without ovarian cancer) at very high familial risk' => :process_scope_r205,
+              'R206 :: Inherited breast cancer ' \
+              'and ovarian cancer at high familial risk levels' => :process_scope_r206,
               'R207 :: Inherited ovarian cancer (without breast cancer)' => :process_scope_r207,
               'R208 :: BRCA1 and BRCA2 testing at high familial risk' => :process_scope_r208,
               'R208 :: Inherited breast cancer and ovarian cancer' => :process_scope_r208,
@@ -174,7 +174,7 @@ module Import
                               'R365 :: Fumarate hydratase-related tumour syndromes'].freeze
 
             BRCA_REGEX = /(?<brca>BRCA1|BRCA2|PALB2|ATM|CHEK2|TP53|MLH1|CDH1|
-                          MSH2|MSH6|PMS2|STK11|PTEN|BRIP1|NBN|RAD51C|RAD51D)/ix.freeze
+                          MSH2|MSH6|PMS2|STK11|PTEN|BRIP1|NBN|RAD51C|RAD51D)/ix
 
             # rubocop:disable Lint/MixedRegexpCaptureTypes
             CDNA_REGEX = /c\.\[?(?<cdna>
@@ -186,22 +186,23 @@ module Import
                                 ([0-9]+[+>_-][0-9]+[+>_-][0-9]+[0-9]+[ACGTdelinsup]+)|
                                 ([0-9]+[?+>_-]+[0-9]+[?+>_-]+[ACGTdelinsup]+)|
                                 ([0-9]+[ACGTdelinsup]+)
-                                )\]?/ix.freeze
+                                )\]?/ix
 
-            MLPA_FAIL_REGEX = /#{BRCA_REGEX}\s(?<mlpa>MLPA?\sfail)+/ix.freeze
+            MLPA_FAIL_REGEX = /#{BRCA_REGEX}\s(?<mlpa>MLPA?\sfail)+/ix
 
             PROTEIN_REGEX = /p\.(\[\()?(?<impact>.([a-z]+[0-9]+[a-z]+([^[:alnum:]][0-9]+)?)|
-                                   ([a-z]+[0-9]+[^[:alnum:]]))(\)\])?/ix.freeze
+                                   ([a-z]+[0-9]+[^[:alnum:]]))(\)\])?/ix
 
             EXON_VARIANT_REGEX = /((?<zygosity>het|homo)[a-z ]+)?
                                   (?<mutationtype>deletion|duplication|duplicated)\s?
-                                  ([a-z 0-9]+(?<nm>exon|exons)\s(?<exons>[0-9]+((to|and|-|\s)+[0-9]+)?))|
+                                  ([a-z 0-9]+(?<nm>exon|exons)\s
+                                  (?<exons>[0-9]+((to|and|-|\s)+[0-9]+)?))|
                                   ((?<zygosity>het|homo)[a-z ]+)?
                                   (?<nm>exon|exons)\s(?<exons>[0-9]+((to|and|-|\s)+[0-9]+)?)
                                   ([a-z ]+(?<mutationtype>deletion|duplication|duplicated))?/ix
 
             NORMAL_VAR_REGEX = %r{(?<not>no|not)[a-z /]+
-                                  (?<det>detect|report|detet|mutation)+}ix.freeze
+                                  (?<det>detect|report|detet|mutation)+}ix
             # rubocop:enable Lint/MixedRegexpCaptureTypes
           end
         end

--- a/lib/import/helpers/brca/providers/rq3/rq3_constants.rb
+++ b/lib/import/helpers/brca/providers/rq3/rq3_constants.rb
@@ -66,8 +66,10 @@ module Import
                                   substitution|
                                   Splice site mutation|
                                   Nonsense/ix
-            EXON_LOCATION = /([a-z (]+)(exon|exons)\s(?<exons>[0-9]+
-                             ([a-z -,]+[0-9]+[a-z -]*[0-9]?)?)?/x
+            EXON_LOCATION = /(?<variant>del|dup|ins).+ex(on)?s?\s?
+                             (?<exons>[0-9]+((to|and|-|\s)+[0-9]+)?)|
+                             ex(on)?s?\s?(?<exons>[0-9]+((to|and|-|\s)+[0-9]+)?)\s?
+                             (?<variant>del|dup|ins)?/x
             MUTATION_REGEX = /(?<mutation>[0-9_-]+(del|ins)[a-z0-9]+)/ix
             MALFORMED_MUTATION_REGEX = %r{(?<cdnamutation>[0-9-]+[ACGT]>[ACGT]+|
             [0-9-]+[ACGT]/[ACGT]+)}ix

--- a/lib/import/helpers/brca/providers/rq3/rq3_helper.rb
+++ b/lib/import/helpers/brca/providers/rq3/rq3_helper.rb
@@ -362,6 +362,7 @@ module Import
 
               genotype.add_status(2)
               genotype.add_exon_location($LAST_MATCH_INFO[:exons])
+              genotype.add_variant_type($LAST_MATCH_INFO[:variant])
             end
 
             def sometimes_tested?

--- a/lib/import/helpers/brca/providers/rr8/constants.rb
+++ b/lib/import/helpers/brca/providers/rr8/constants.rb
@@ -139,19 +139,16 @@ module Import
 
             PROTEIN_REGEX = /\(?p\.\(?(?<impact>\w+)\)?/ix
 
-            EXON_VARIANT_REGEX = /(?<variant>del|dup|ins).+ex(?<on>on)?(?<s>s)?\s
-                                  (?<exons>[0-9]+(?<dgs>-[0-9]+)?)|
-                                ex(?<on>on)?(?<s>s)?\s?(?<exons>[0-9]+(?<dgs>-[0-9]+)?)\s?
-                                (?<variant>del|dup|ins)|
-                                (?<variant>del|dup|ins)\sexon(?<s>s)?\s
-                                (?<exons>[0-9]+(?<dgs>\sto\s[0-9]+))|
-                                ex(on)?(s)?\s?(?<exons>[0-9]+\s?(\s?-\s?[0-9]+)?)\s?
-                                (?<variant>del|dup|ins)?|
-                                (?<variant>del|dup|ins)(?<s>\s)?(?<exons>[0-9]+(?<dgs>-[0-9]+)?)|
-                                ex(?<on>on)?(?<s>s)?\s(?<exons>[0-9]+(?<dgs>\sto\s[0-9]+)?)\s
-                                (?<variant>del|dup|ins)|
-                                x(?<exons>[0-9]+-?[0-9]+)\s?(?<variant>del|dup|ins)|
-                                x(?<exons>[0-9]+-?[0-9]?)\s?(?<variant>del|dup|ins)/ix
+            EXON_VARIANT_REGEX = /(?<variant>del|dup|ins).+ex(on)?s?\s?
+                                  (?<exons>[0-9]+(-[0-9]+)?)|
+                                  ex(on)?s?\s?(?<exons>[0-9]+(-[0-9]+)?)\s?
+                                  (?<variant>del|dup|ins)|
+                                  ex(on)?s?\s?(?<exons>[0-9]+\s?(\s?-\s?[0-9]+)?)\s?
+                                  (?<variant>del|dup|ins)?|
+                                  (?<variant>del|dup|ins)\s?(?<exons>[0-9]+(?<dgs>-[0-9]+)?)|
+                                  ex(on)?s?\s?(?<exons>[0-9]+(\sto\s[0-9]+)?)\s
+                                  (?<variant>del|dup|ins)|
+                                  x(?<exons>[0-9+-? ]+)+(?<variant>del|dup|ins)/ix
             # rubocop:enable Lint/MixedRegexpCaptureTypes
           end
         end

--- a/lib/import/helpers/brca/providers/rtd/rtd_constants.rb
+++ b/lib/import/helpers/brca/providers/rtd/rtd_constants.rb
@@ -77,19 +77,13 @@ module Import
                                  [0-9]+[+>_-][0-9]+[+>_-][0-9]+[ACGTdelinsup]+|
                                  [0-9]+.[0-9]+[a-z]+>[a-z]+)\s?/ix
 
-            EXON_VARIANT_REGEX = /(?<variant>del|dup|ins).+ex(?<on>on)?(?<s>s)?\s
-                                  (?<exons>[0-9]+(?<dgs>-[0-9]+)?)|
-                                ex(?<on>on)?(?<s>s)?\s?(?<exons>[0-9]+(?<dgs>-[0-9]+)?)\s?
-                                (?<variant>del|dup|ins)|
-                                (?<variant>del|dup|ins)\sexon(?<s>s)?\s
-                                (?<exons>[0-9]+(?<dgs>\sto\s[0-9]+))|
-                                ex(on)?(s)?\s?(?<exons>[0-9]+\s?(\s?-\s?[0-9]+)?)\s?
-                                (?<variant>del|dup|ins)?|
-                                (?<variant>del|dup|ins)(?<s>\s)?(?<exons>[0-9]+(?<dgs>-[0-9]+)?)|
-                                ex(?<on>on)?(?<s>s)?\s(?<exons>[0-9]+(?<dgs>\sto\s[0-9]+)?)\s
-                                (?<variant>del|dup|ins)|
-                                x(?<exons>[0-9]+-?[0-9]+)\s?(?<variant>del|dup|ins)|
-                                x(?<exons>[0-9]+-?[0-9]?)\s?(?<variant>del|dup|ins)/ix
+            EXON_VARIANT_REGEX = /(?<variant>del|dup|ins).+ex(on)?s?\s?
+                                  (?<exons>[0-9]+((to|and|-|\s)+[0-9]+)?)|
+                                  ex(on)?s?\s?(?<exons>[0-9]+((to|and|-|\s)+[0-9]+)?)\s?
+                                  (?<variant>del|dup|ins)?|
+                                  x(?<exons>[0-9+-? ]+)+(?<variant>del|dup|ins)|
+                                  ^(?<variant>del|dup|ins)\s?(?<exons>[0-9]+((to|and|-|\s)+[0-9]+)?)
+                                  /ix
             # rubocop:enable Lint/MixedRegexpCaptureTypes
           end
         end

--- a/lib/import/helpers/brca/providers/rx1/rx1_constants.rb
+++ b/lib/import/helpers/brca/providers/rx1/rx1_constants.rb
@@ -61,9 +61,8 @@ module Import
 
             CDNA_REGEX = /c\.(?<cdna>.?[0-9]+[^\s|^, ]+)/i
 
-            EXON_REGEX = /ex(?<ons>[a-z]+)?\s?(?<exons>[0-9]+(?<otherexons>-[0-9]+)?)\s
-                          (?<vartype>del|dup)|(?<vartype>del[a-z]+|dup[a-z]+)(?<of>\sof)?\s
-                          exon(?<s>s)?\s(?<exons>[0-9]+(?<otherexons>-[0-9]+)?)/xi
+            EXON_REGEX = /ex([a-z ]+)?(?<exons>\d+([a-z -]+\d+)?)\s+(?<vartype>del|dup)|
+                          (?<vartype>del[a-z ]+|dup[a-z ]+)exon(s)?\s(?<exons>\d+([a-z -]+\d+)?)/xi
 
             PROTEIN_REGEX = /p\..(?<impact>.+)\)/i
           end

--- a/lib/import/helpers/brca/providers/rx1/rx1_constants.rb
+++ b/lib/import/helpers/brca/providers/rx1/rx1_constants.rb
@@ -58,13 +58,14 @@ module Import
 
             NEGATIVE_TEST = /Normal/i
             VARPATHCLASS_REGEX = /(?<varpathclass>[0-9](?=:))/
-
+            # rubocop:disable Lint/MixedRegexpCaptureTypes
             CDNA_REGEX = /c\.(?<cdna>.?[0-9]+[^\s|^, ]+)/i
 
             EXON_REGEX = /ex([a-z ]+)?(?<exons>\d+([a-z -]+\d+)?)\s+(?<vartype>del|dup)|
                           (?<vartype>del[a-z ]+|dup[a-z ]+)exon(s)?\s(?<exons>\d+([a-z -]+\d+)?)/xi
 
             PROTEIN_REGEX = /p\..(?<impact>.+)\)/i
+            # rubocop:enable Lint/MixedRegexpCaptureTypes
           end
         end
       end

--- a/test/lib/import/brca/providers/birmingham/birmingham_handler_newformat_test.rb
+++ b/test/lib/import/brca/providers/birmingham/birmingham_handler_newformat_test.rb
@@ -97,6 +97,8 @@ class BirminghamHandlerNewformatTest < ActiveSupport::TestCase
     assert_equal 7, genotypes[1].attribute_map['gene']
     assert_equal 2, genotypes[1].attribute_map['teststatus']
     assert_equal '16', genotypes[1].attribute_map['exonintroncodonnumber']
+    assert_equal 3, genotypes[1].attribute_map['sequencevarianttype']
+    assert_equal 1, genotypes[1].attribute_map['variantlocation']
   end
 
   test 'process_multiple_variants_single_gene' do
@@ -348,6 +350,21 @@ class BirminghamHandlerNewformatTest < ActiveSupport::TestCase
     assert_equal 2, genotypes[0].attribute_map['teststatus']
     assert_equal 3, genotypes[0].attribute_map['variantpathclass']
     # we do not capture proteins when cdnas are more than proteins to avoid wrong assosciation
+  end
+
+  test 'process exonic record' do
+    exonic_rec = build_raw_record('pseudo_id1' => 'bob')
+    exonic_rec.raw_fields['moleculartestingtype'] = 'confirmation'
+    exonic_rec.raw_fields['teststatus'] = 'Molecular analysis shows presence of a pathogenic deletion (exons 14 to 20) in the BRCA1 gene.'
+    processor = variant_processor_for(exonic_rec)
+    @handler.process_genetictestscope(@genotype, exonic_rec)
+    genotypes = processor.process_variants_from_report
+    assert_equal 1, genotypes.size
+    assert_equal '14-20', genotypes[0].attribute_map['exonintroncodonnumber']
+    assert_equal 3, genotypes[0].attribute_map['sequencevarianttype']
+    assert_equal 1, genotypes[0].attribute_map['variantlocation']
+    assert_equal 7, genotypes[0].attribute_map['gene']
+    assert_equal 2, genotypes[0].attribute_map['teststatus']
   end
 
   private

--- a/test/lib/import/brca/providers/leeds/leeds_handler_new_test.rb
+++ b/test/lib/import/brca/providers/leeds/leeds_handler_new_test.rb
@@ -142,6 +142,7 @@ class LeedsHandlerNewTest < ActiveSupport::TestCase
     assert_equal 7, genotypes[0].attribute_map['gene']
     assert_equal 5, genotypes[0].attribute_map['variantpathclass']
     assert_equal '3', genotypes[0].attribute_map['exonintroncodonnumber']
+    assert_equal 3, genotypes[0].attribute_map['sequencevarianttype']
 
     assert_equal 1, genotypes[1].attribute_map['teststatus']
     assert_equal 8, genotypes[1].attribute_map['gene']

--- a/test/lib/import/brca/providers/newcastle/newcastle_handler_test.rb
+++ b/test/lib/import/brca/providers/newcastle/newcastle_handler_test.rb
@@ -479,13 +479,28 @@ class NewcastleHandlerTest < ActiveSupport::TestCase
     assert_nil genotypes[0].attribute_map['codingdnasequencechange']
   end
 
-  test 'variantpathclass assignes to only gene in raw[gene]' do
+  test 'variantpathclass assigns to only gene in raw[gene]' do
     @handler.process_test_scope(@genotype, @record)
     genotypes = @handler.process_variant_records(@genotype, @record)
     assert_nil genotypes[0].attribute_map['variantpathclass']
     assert_equal 8, genotypes[0].attribute_map['gene']
     assert_equal 3, genotypes[1].attribute_map['variantpathclass']
     assert_equal 7, genotypes[1].attribute_map['gene']
+  end
+
+  test 'exonic variant records are populating attributes' do
+    exonic_var_rec = build_raw_record('pseudo_id1' => 'bob')
+    exonic_var_rec.raw_fields['moleculartestingtype'] = 'presymptomatic'
+    exonic_var_rec.raw_fields['service category'] = 'B'
+    exonic_var_rec.raw_fields['investigationcode'] = 'BRCA-PRED'
+    exonic_var_rec.raw_fields['gene'] = 'BRCA1'
+    exonic_var_rec.raw_fields['genotype'] = 'del ex2-24'
+    @handler.process_test_scope(@genotype, exonic_var_rec)
+    genotypes = @handler.process_variant_records(@genotype, exonic_var_rec)
+    assert_equal 3, genotypes[0].attribute_map['sequencevarianttype']
+    assert_equal '2-24', genotypes[0].attribute_map['exonintroncodonnumber']
+    assert_equal 1, genotypes[0].attribute_map['variantlocation']
+    assert_equal 7, genotypes[0].attribute_map['gene']
   end
 
   private

--- a/test/lib/import/brca/providers/oxford/oxford_handler_test.rb
+++ b/test/lib/import/brca/providers/oxford/oxford_handler_test.rb
@@ -87,7 +87,7 @@ class OxfordHandlerTest < ActiveSupport::TestCase
     exon_variant_record.mapped_fields['codingdnasequencechange'] = 'Deletion of exon 12-24'
     @handler.process_variants(@genotype, exon_variant_record, 5)
     assert_equal '12-24', @genotype.attribute_map['exonintroncodonnumber']
-    assert_equal 10, @genotype.attribute_map['sequencevarianttype']
+    assert_equal 3, @genotype.attribute_map['sequencevarianttype']
     assert_equal 2, @genotype.attribute_map['teststatus']
     normal_record = build_raw_record('pseudo_id1' => 'bob')
     normal_record.raw_fields['codingdnasequencechange'] = 'N/A'
@@ -109,7 +109,7 @@ class OxfordHandlerTest < ActiveSupport::TestCase
     nonpath_exon_variant_record.mapped_fields['codingdnasequencechange'] = 'Deletion of exon 12-24'
     @handler.process_variants(@genotype, nonpath_exon_variant_record, 2)
     assert_equal '12-24', @genotype.attribute_map['exonintroncodonnumber']
-    assert_equal 10, @genotype.attribute_map['sequencevarianttype']
+    assert_equal 3, @genotype.attribute_map['sequencevarianttype']
     assert_equal 10, @genotype.attribute_map['teststatus']
 
     exemptions_del_record = build_raw_record('pseudo_id1' => 'bob')

--- a/test/lib/import/brca/providers/royal_marsden/royal_marsden_handler_test.rb
+++ b/test/lib/import/brca/providers/royal_marsden/royal_marsden_handler_test.rb
@@ -86,6 +86,8 @@ class RoyalMarsdenHandlerTest < ActiveSupport::TestCase
     deldup_record.raw_fields['teststatus'] = 'Exon 9-10 deletion'
     @handler.process_large_deldup(@genotype, deldup_record)
     assert_equal '9-10', @genotype.attribute_map['exonintroncodonnumber']
+    assert_equal 3, @genotype.attribute_map['sequencevarianttype']
+    assert_equal 1, @genotype.attribute_map['variantlocation']
   end
 
   test 'process_test_type' do

--- a/test/lib/import/brca/providers/salisbury/salisbury_handler_test.rb
+++ b/test/lib/import/brca/providers/salisbury/salisbury_handler_test.rb
@@ -33,6 +33,15 @@ class SalisburyHandlerTest < ActiveSupport::TestCase
     assert_equal 1, @genotype.attribute_map['sequencevarianttype']
   end
 
+  test 'process_exonic_variants' do
+    exonic_record = build_raw_record('pseudo_id1' => 'bob')
+    exonic_record.raw_fields['genotype'] = 'exons 21-24'
+    @handler.process_variants(@genotype, exonic_record.raw_fields['genotype'])
+    assert_equal '21-24', @genotype.attribute_map['exonintroncodonnumber']
+    assert_equal 10, @genotype.attribute_map['sequencevarianttype']
+    assert_equal 1, @genotype.attribute_map['variantlocation']
+  end
+
   test 'add_organisationcode_testresult' do
     @handler.add_organisationcode_testresult(@genotype)
     assert_equal '699H0', @genotype.attribute_map['organisationcode_testresult']

--- a/test/lib/import/brca/providers/sheffield/sheffield_handler_test.rb
+++ b/test/lib/import/brca/providers/sheffield/sheffield_handler_test.rb
@@ -172,6 +172,8 @@ class SheffieldHandlerTest < ActiveSupport::TestCase
     assert_equal 2, genotypes[0].attribute_map['teststatus']
     assert_equal 7, genotypes[0].attribute_map['gene']
     assert_equal '1and2', genotypes[0].attribute_map['exonintroncodonnumber']
+    assert_equal 3, genotypes[0].attribute_map['sequencevarianttype']
+    assert_equal 1, genotypes[0].attribute_map['variantlocation']
 
     assert_equal 2, genotypes[1].attribute_map['teststatus']
     assert_equal 8, genotypes[1].attribute_map['gene']


### PR DESCRIPTION
## What?
Added variant location across the BRCA labs. Also amended regex to extract exonic variants and populate sequencevarianttype in genotype.

## Why?
Above information was present in raw records and needs to be extracted and populated in genotype.

## Testing?
Added and updated tests, Denominators counts before and after changes have been checked for each lab.