### PR TITLE
Tolerate IDP time drift in devise config

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -281,5 +281,5 @@ Devise.setup do |config|
 
   config.saml_session_index_key = :session_index
 
-  config.allowed_clock_drift_in_seconds = 1.second
+  config.allowed_clock_drift_in_seconds = 5.minutes
 end


### PR DESCRIPTION
A running instance of the app experienced clock drift between it's host and the trusted IdP.  The tight default tolerances in the default devise meant this broke SAML response validation when the IdP drifted ahead of the app host.

This PR relaxes the default config which, given the other controls in place in the only known deployment, should be pragmatic and safe