### PR TITLE
exclude other files from newcastle brca

### DIFF
--- a/lib/import/brca/scripts/bash/Import_all_brca_interactive.sh
+++ b/lib/import/brca/scripts/bash/Import_all_brca_interactive.sh
@@ -41,6 +41,7 @@ for x in $(find  $DIRPATH/$FILEPATH -type f -name "*.pseudo" -path "*/$PROV/*" \
 -not -path "*/2017/*" \
 ! -name "*Colorectal*" \
 ! -name "*Other*" \
+! -name "*other*" \
 ! -name "*CAPP2*")
 do
 IFS="$OIFS"


### PR DESCRIPTION
## What?

Excluding "other" named files as records from the Newcastle lab where the filename contains the word ‘other’ are not genuine BRCA tests