### PR TITLE
importer fix for old st george hander

### DIFF
--- a/lib/import/brca/providers/st_george_old/st_george_handler_old.rb
+++ b/lib/import/brca/providers/st_george_old/st_george_handler_old.rb
@@ -54,12 +54,13 @@ module Import
           DELIMETER_REGEX = /[&\n+,;]|and|IFD/i.freeze
 
           def process_fields(record)
-            genotype = Import::Brca::Core::GenotypeBrca.new(record)
+
+            #binding.pry
 
             #records using new importer should only have SRIs starting with D
             return unless record.raw_fields['servicereportidentifier'].start_with?("D")
-
-            
+            genotype = Import::Brca::Core::GenotypeBrca.new(record)
+  
             genotype.add_passthrough_fields(record.mapped_fields,
                                             record.raw_fields,
                                             PASS_THROUGH_FIELDS)
@@ -67,11 +68,19 @@ module Import
             add_moleculartestingtype(genotype, record)
             process_genetictestcope(genotype, record)
             res = process_variants_from_record(genotype, record)
+
+            #correcting ebatch provider and registry to RJ7 (from RJ7_2) to allow data to persist in the database
+            @batch.provider ='RJ7'
+            @batch.registryid = 'RJ7'
+
+            binding.pry
+
             res.each { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
           end
 
           def add_organisationcode_testresult(genotype)
             genotype.attribute_map['organisationcode_testresult'] = '697N0'
+          
           end
 
           def add_moleculartestingtype(genotype, record)

--- a/lib/import/brca/providers/st_george_old/st_george_handler_old.rb
+++ b/lib/import/brca/providers/st_george_old/st_george_handler_old.rb
@@ -54,11 +54,10 @@ module Import
           DELIMETER_REGEX = /[&\n+,;]|and|IFD/i.freeze
 
           def process_fields(record)
+            # records using new importer should only have SRIs starting with D
+            return unless record.raw_fields['servicereportidentifier'].start_with?('D')
 
-            #records using new importer should only have SRIs starting with D
-            return unless record.raw_fields['servicereportidentifier'].start_with?("D")
             genotype = Import::Brca::Core::GenotypeBrca.new(record)
-  
             genotype.add_passthrough_fields(record.mapped_fields,
                                             record.raw_fields,
                                             PASS_THROUGH_FIELDS)
@@ -66,11 +65,9 @@ module Import
             add_moleculartestingtype(genotype, record)
             process_genetictestcope(genotype, record)
             res = process_variants_from_record(genotype, record)
-
-            #correcting ebatch provider and registry to RJ7 (from RJ7_2) to allow data to persist in the database
-            @batch.provider ='RJ7'
+            # correcting ebatch provider and registry to RJ7 (from RJ7_2) to allow data to persist in the database
+            @batch.provider = 'RJ7'
             @batch.registryid = 'RJ7'
-
             res.each { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
           end
 

--- a/lib/import/brca/providers/st_george_old/st_george_handler_old.rb
+++ b/lib/import/brca/providers/st_george_old/st_george_handler_old.rb
@@ -55,8 +55,6 @@ module Import
 
           def process_fields(record)
 
-            #binding.pry
-
             #records using new importer should only have SRIs starting with D
             return unless record.raw_fields['servicereportidentifier'].start_with?("D")
             genotype = Import::Brca::Core::GenotypeBrca.new(record)
@@ -72,8 +70,6 @@ module Import
             #correcting ebatch provider and registry to RJ7 (from RJ7_2) to allow data to persist in the database
             @batch.provider ='RJ7'
             @batch.registryid = 'RJ7'
-
-            binding.pry
 
             res.each { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
           end

--- a/lib/import/brca/scripts/bash/Import_all_brca_interactive.sh
+++ b/lib/import/brca/scripts/bash/Import_all_brca_interactive.sh
@@ -202,7 +202,8 @@ for x in $(find  $DIRPATH/$FILEPATH -type f -name "*.pseudo" -path "*/$PROV/*" \
 -not -path "*/2021/*" \
 -not -path "*/2022/*" \
 -not -path "*/2023/*" \
-! -name "c466c80823235315f4df98bb4a14c4937ee5cbc4_08.2020_STG HBOC PHE reported till 28082020.xlsx.pseudo" \
+! -iname "*CRC*.pseudo" \
+! -iname "*colorectal*.pseudo" \
 ! -name "*HBOC*")
 do
 IFS="$OIFS"

--- a/test/fixtures/zproviders.yml
+++ b/test/fixtures/zproviders.yml
@@ -6,3 +6,5 @@ zprovider_rgt:
   zproviderid: RGT
 zprovider_r0a:
   zproviderid: R0A
+zprovider_rj7:
+  zproviderid: RJ7

--- a/test/lib/import/brca/providers/st_george_old/st_george_handler_old_test.rb
+++ b/test/lib/import/brca/providers/st_george_old/st_george_handler_old_test.rb
@@ -10,6 +10,18 @@ class StGeorgeHandlerOldTest < ActiveSupport::TestCase
     @logger = Import::Log.get_logger
   end
 
+  test 'process_fields' do
+    e_batch = EBatch.create(original_filename: 'test_file',
+                            e_type:            'PSMOLE',
+                            provider:          'RJ7_2',
+                            registryid:        'RJ7_2')
+    handler = Import::Brca::Providers::StGeorgeOld::StGeorgeHandlerOld.new(e_batch)
+    handler.process_fields(@record)
+    assert_difference('EBatch.count', 1) do
+      handler.finalize
+    end
+  end
+
   test 'process_moltesttype' do
     predictive_record = build_raw_record('pseudo_id1' => 'bob')
     predictive_record.raw_fields['moleculartestingtype'] = 'unaffected'

--- a/test/lib/import/brca/providers/st_george_old/st_george_handler_old_test.rb
+++ b/test/lib/import/brca/providers/st_george_old/st_george_handler_old_test.rb
@@ -20,6 +20,10 @@ class StGeorgeHandlerOldTest < ActiveSupport::TestCase
     assert_difference('EBatch.count', 1) do
       handler.finalize
     end
+    # confirm batch created now has 'RJ7' as provider
+    e_batch.reload
+    assert_equal 'RJ7', e_batch.provider
+    assert_equal 'RJ7', e_batch.registryid
   end
 
   test 'process_moltesttype' do


### PR DESCRIPTION
What?
PR to fix issue with running two handlers for one provider (St George's BRCA). 

How ?
Replacing the ebatch registry code and provider code before data is persisted in the database will permit two seperate handlers to be run for the same provider code.

Testing?
Added relevant test case for method.

Anything Else?
