### PR TITLE
Updating RQ3 script to exclude Rare files case insensitive mode

### DIFF
--- a/lib/import/brca/scripts/bash/Import_all_brca_interactive.sh
+++ b/lib/import/brca/scripts/bash/Import_all_brca_interactive.sh
@@ -117,11 +117,10 @@ PROV='RQ3'
 IFS=$'\n'
 for x in $(find  $DIRPATH/$FILEPATH -type f -name "*.pseudo" -path "*/$PROV/*" \
 -not -path "*/2018-02-06/*" \
-! -name "*Rare*" \
-! -name "*Colon*" \
-! -name "*COLON*" \
-! -name "*non BRCA*" \
-! -name "*bwnft*"  )
+! -iname "*Rare*" \
+! -iname "*Colon*" \
+! -iname "*non BRCA*" \
+! -iname "*bwnft*"  )
   do
   IFS="$OIFS"
   $BRAKE import:brca fname="$(echo "$x" | sed -e 's:.*pseudonymised_data/\(.*\):\1:')" prov_code=$PROV


### PR DESCRIPTION
## What?
Updating RQ3 script to exclude Rare files case insensitive mode

## Why?
While running script for CASREF REFRESH , BRCA Birmingham importer failed for `...2023_Q1 RARE.xlsx.pseudo` which ideally shouldn't have been picked by BRCA handlers.

## Testing?
Ran RQ3 script and now rake doesn't get aborted .