### PR TITLE
updated rcu script

### DIFF
--- a/lib/import/colorectal/scripts/bash/Import_all_colorectal_interactive.sh
+++ b/lib/import/colorectal/scripts/bash/Import_all_colorectal_interactive.sh
@@ -65,7 +65,8 @@ PROV='RCU'
 IFS=$'\n'
 for x in $(find $DIRPATH/$FILEPATH -type f -path "*/$PROV/*" \
 \( -iname "*lynch*.pseudo" -o -iname "*colorectal*.pseudo" -o -iname "*crc*.pseudo" -o \
-	-name "*1dbb561a296d1efcf685bd67a3b*pseudo" \) \
+	-name "*1dbb561a296d1efcf685bd67a3b*pseudo" -o \
+	-name "*b20327dfab493e86e7f65e89663fb551*pseudo" \) \
 ! -iname "*NON_BRCA_CRC*" \
 ! -iname "*NonBRCA_CRC*" \
 ! -iname "*Non_CRC*" \


### PR DESCRIPTION
## What?

RCU colorectal script should also import one wrongly labelled BRCA file.

## Why?

Its a mixed file to be imported by both BRCA and CRC handler.

## How?
Added to RCU script
