### PR TITLE
changed teststatus mapping for unknown and added test

### DIFF
--- a/lib/import/helpers/brca/providers/rvj/rvj_constants.rb
+++ b/lib/import/helpers/brca/providers/rvj/rvj_constants.rb
@@ -21,7 +21,7 @@ module Import
                                'Likely Deleterious' => :positive,
                                'Likely Pathogenic' => :positive,
                                'Pathogenic' => :positive,
-                               'Unknown' => :positive }.freeze
+                               'Unknown' => 3 }.freeze
           end
         end
       end

--- a/test/lib/import/brca/providers/bristol/bristol_handler_test.rb
+++ b/test/lib/import/brca/providers/bristol/bristol_handler_test.rb
@@ -39,6 +39,18 @@ class BristolHandlerTest < ActiveSupport::TestCase
     assert_equal 8, res[1].attribute_map['gene']
   end
 
+  test 'process_unknown_record' do
+    normal_record = build_raw_record('pseudo_id1' => 'bob')
+    normal_record.raw_fields['variantpathclass'] = 'Unknown'
+    @handler.process_test_status(@genotype, normal_record)
+    res = @handler.process_gene(@genotype, normal_record)
+    assert_equal 2, res.size
+    assert_equal 1, res[0].attribute_map['teststatus']
+    assert_equal 7, res[0].attribute_map['gene']
+    assert_equal 3, res[1].attribute_map['teststatus']
+    assert_equal 8, res[1].attribute_map['gene']
+  end
+
   test 'process_protein_impact' do
     @handler.add_protein_impact(@genotype, @record)
     assert_equal 'p.Asp2723His', @genotype.attribute_map['proteinimpact']


### PR DESCRIPTION
**What?**
Changed mapped test status for Unknown from 10 to 3.

**How?**
Changed the value in the TESTSTATUS_MAP dictionary in the constants and added a test to check that 3 is correctly assigned to a status of Unknown

**Why?**
variantpathclass values of Unknown were being assigned a teststatus of 2 in the handler, this is incorrect and these records should be given a teststatus of 3. 

