### PR TITLE
Removing 'TP53' files

### DIFF
--- a/lib/import/brca/scripts/bash/Import_all_brca_interactive.sh
+++ b/lib/import/brca/scripts/bash/Import_all_brca_interactive.sh
@@ -203,7 +203,8 @@ for x in $(find  $DIRPATH/$FILEPATH -type f -name "*.pseudo" -path "*/$PROV/*" \
 -not -path "*/2023/*" \
 ! -iname "*CRC*.pseudo" \
 ! -iname "*colorectal*.pseudo" \
-! -name "*HBOC*")
+! -name "*HBOC*" \
+! -name "*TP53*")
 do
 IFS="$OIFS"
 $BRAKE import:brca fname="$(echo "$x" | sed -e 's:.*pseudonymised_data/\(.*\):\1:')" prov_code=$PROV_OLD_FILE


### PR DESCRIPTION
## What?

Removing "TP53" files from being processed via BRCA old importer

## Why?
Requirement to not parse filenames that contain 'TP53' in their title.

## Testing?
Have checked not parsing 2 TP53 files now.
