### PR TITLE
Missing SRIs fix

### DIFF
--- a/lib/import/colorectal/core/genocolorectal.rb
+++ b/lib/import/colorectal/core/genocolorectal.rb
@@ -37,6 +37,9 @@ module Import
                            'TP53' => 79,
                            'PALB2' => 3186,
                            'RNF43' => 5019,
+                           'CHEK2' => 865,
+                           'RAD51C' => 3615,
+                           'RAD51D' => 3616,
                            'VHL' => 83,
                            'ATM' => 451 }.freeze
 
@@ -62,6 +65,9 @@ module Import
                             (?<tp53>TP53)|
                             (?<palb2>PALB2)|
                             (?<rnf43>RNF43)|
+                            (?<chek2>CHEK2)|
+                            (?<rad51c>RAD51C)|
+                            (?<rad51d>RAD51D)|
                             (?<vhl>VHL) |
                             (?<atm>ATM)/ix # Added by Francesco
 

--- a/lib/import/helpers/colorectal/providers/rr8/constants.rb
+++ b/lib/import/helpers/colorectal/providers/rr8/constants.rb
@@ -16,6 +16,7 @@ module Import
                                     'r209.1' => :full_screen,
                                     'r209.2' => :full_screen,
                                     'r210.5' => :full_screen,
+                                    'r210.1' => :full_screen,
                                     'r210.2' => :full_screen,
                                     'r211.1' => :full_screen,
                                     'r211.2' => :full_screen,

--- a/test/lib/import/colorectal/providers/leeds/leeds_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/leeds/leeds_handler_colorectal_test.rb
@@ -228,6 +228,25 @@ class LeedsHandlerColorectalTest < ActiveSupport::TestCase
     assert_equal 'p.Arg300Gln', genotypes[14].attribute_map['proteinimpact']
   end
 
+  test 'fs record with no gene info in genotype or report, so genes extracted from mtype' do
+    fail_fs_no_gene_rec = build_raw_record('pseudo_id1' => 'bob')
+    fail_fs_no_gene_rec.raw_fields['moleculartestingtype'] = 'Diagnostic; Lynch'
+    fail_fs_no_gene_rec.raw_fields['genotype'] = 'Fail/Results not required'
+    fail_fs_no_gene_rec.raw_fields['report'] = nil
+
+    @handler.populate_variables(fail_fs_no_gene_rec)
+    @handler.add_varclass
+    @handler.add_scope(@genotype, fail_fs_no_gene_rec)
+    genotypes = @handler.process_variants_from_record(@genotype, fail_fs_no_gene_rec)
+
+    assert_equal 4, genotypes.size
+    assert_equal [9], genotypes.collect { |g| g.attribute_map['teststatus'] }.uniq
+    assert_equal 2744, genotypes[0].attribute_map['gene']
+    assert_equal 2804, genotypes[1].attribute_map['gene']
+    assert_equal 2808, genotypes[2].attribute_map['gene']
+    assert_equal 3394, genotypes[3].attribute_map['gene']
+  end
+
   private
 
   def clinical_json


### PR DESCRIPTION
## What?

During last CASREF Refresh , Fiona identified missing SRIs from MMR files that didn't get imported in database.

## Why?
The records didn't have any gene info and hence got skipped from getting persisted in db.

## How?
Fiona has provided new rule to get genes based on Moleculartestingtype if couldn't determine from report or genotype. Also if no gene is present then record must get persisted in DB without gene info.

## Testing ?
Test have been added and ran importer locally to see missing SRIs are now getting persisted.