### PR TITLE
Feature/36735/oxford slowness

### DIFF
--- a/lib/import/brca/providers/oxford/oxford_handler.rb
+++ b/lib/import/brca/providers/oxford/oxford_handler.rb
@@ -11,7 +11,8 @@ module Import
 
             return if @files_not_to_process.include? @file_name
 
-            if brca_file?
+            if @files_to_process.include?(@file_name) || brca_file?
+              @files_to_process << @file_name unless @files_to_process.include?(@file_name)
               prepare_genotypes(record)
             else
               @files_not_to_process << @file_name

--- a/lib/import/colorectal/providers/oxford/oxford_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/oxford/oxford_handler_colorectal.rb
@@ -11,7 +11,8 @@ module Import
 
             return if @files_not_to_process.include? @file_name
 
-            if colorectal_file?
+            if @files_to_process.include?(@file_name) || colorectal_file?
+              @files_to_process << @file_name unless @files_to_process.include?(@file_name)
               prepare_genotypes(record)
             else
               @files_not_to_process << @file_name

--- a/lib/import/colorectal/providers/oxford/oxford_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/oxford/oxford_handler_colorectal.rb
@@ -7,8 +7,18 @@ module Import
           include Import::Helpers::Colorectal::Providers::Rth::Constants
 
           def process_fields(record)
-            return unless colorectal_file?
+            @file_name = @batch.original_filename
 
+            return if @files_not_to_process.include? @file_name
+
+            if colorectal_file?
+              prepare_genotypes(record)
+            else
+              @files_not_to_process << @file_name
+            end
+          end
+
+          def prepare_genotypes(record)
             genocolorectal = Import::Colorectal::Core::Genocolorectal.new(record)
             genocolorectal.add_passthrough_fields(record.mapped_fields,
                                                   record.raw_fields,
@@ -84,7 +94,7 @@ module Import
             else
               varpath = VAR_PATH_CLASS_MAP[varpathclass]
             end
-            genocolorectal.add_variant_class(varpath)
+            genocolorectal.add_variant_class(varpath) if varpath.present?
           end
 
           def assign_servicereportidentifier(genocolorectal, record)

--- a/lib/import/germline/provider_handler.rb
+++ b/lib/import/germline/provider_handler.rb
@@ -9,6 +9,7 @@ module Import
         @batch = batch
         attach_persister(batch)
         @files_not_to_process = []
+        @files_to_process = []
       end
 
       def attach_persister(batch)

--- a/lib/import/germline/provider_handler.rb
+++ b/lib/import/germline/provider_handler.rb
@@ -8,6 +8,7 @@ module Import
         @lines_processed = 0
         @batch = batch
         attach_persister(batch)
+        @files_not_to_process = []
       end
 
       def attach_persister(batch)


### PR DESCRIPTION
## What?

Oxford's scripts were too slow and taking hours to finish up , making it hard to bring any changes as everytime a lot of developer's time was going in executing it. More details on planio - 36735

## Why?
For every record coming , check was being made if the file it belongs to is relevant to process under current handler or not.

## How?
I have checked on first incoming record , if the file should be processed or not and return early if its not to be processed rather checking everytime for each record.

## Testing ?
Locally tested via timing the script and here are the changes in timings - 

Old - 
BRCA script finishes at - Total time taken - 0 hours, 55 minutes, and 51 seconds.
CRC script finishes at - Total time taken - 0 hours, 40 minutes, and 19 seconds.

New times -
CRC - Total time taken - 0 hours, 10 minutes, and 38 seconds.
BRCA - Total time taken - 0 hours, 11 minutes, and 19 seconds.

Also compared the counts before and after changes and they stay the same.