### PR TITLE
Fixed regex to capture variants to avoid incompatible varpathclass and teststatus

### DIFF
--- a/lib/import/brca/providers/oxford/oxford_handler.rb
+++ b/lib/import/brca/providers/oxford/oxford_handler.rb
@@ -233,7 +233,7 @@ module Import
 
             exemptions = record.mapped_fields['codingdnasequencechange']
             if exemptions.scan('c.').size.positive?
-              genotype.add_gene_location(exemptions.gsub(/[\[\]+=]+/, ''))
+              genotype.add_gene_location(exemptions.gsub(/[() ]+/, ''))
             elsif exemptions.scan(/(?<delinsdup>del|ins|dup)/i).size.positive?
               genotype.add_variant_type($LAST_MATCH_INFO[:delinsdup])
               if exemptions.scan(/(?<exon>[0-9]+-[0-9]+)/i).size.positive?

--- a/lib/import/helpers/brca/providers/rth/constants.rb
+++ b/lib/import/helpers/brca/providers/rth/constants.rb
@@ -54,19 +54,19 @@ module Import
             GENE_VALUES = [7, 8, 590, 18, 20, 865, 2744, 2804, 2808, 3186, 3394, 62, 3615, 3616, 76, 79, 358,
                            451, 577, 794, 1432, 1590, 1882, 2850, 3108, 3408, 5000, 5019, 72].freeze
 
-            RECORD_EXEMPTIONS = ['c.[-835C>T]+[=]', 'Deletion of whole PTEN gene',
-                                 'c.[-904_-883dup ]+[=]', 'whole gene deletion',
+            RECORD_EXEMPTIONS = ['c.( 442-127_ 593+118)', 'Deletion of whole PTEN gene', 'whole gene deletion',
                                  'Deletion partial exon 11 and exons 12-15', 'whole gene duplication'].freeze
 
             PROTEIN_REGEX = /p\.\[?\(?(?<impact>.+)(?:\))|
                              p\.\[(?<impact>[a-z0-9*]+)\]|
                              p\.(?<impact>[a-z]+[0-9]+[a-z]+)/ix
 
-            CDNA_REGEX = /c\.\[?(?<cdna>[0-9]+.+[a-z]+)\]?/i
+            CDNA_REGEX = /c\.\[?(?<cdna>[0-9-]+.+[a-z]+)\]?/i
 
             EXON_REGEX = /(?<mutationtype>del|inv|dup).+ion\s[a-z0-9]*\s?exons?\s?(?<exons>[0-9]+(?:-[0-9]+)?)|
                           ex(?:on|ons)?\s?(?<exons>[0-9]+(?:(?:-|\+)[0-9]+)?)\s?(?<mutationtype>del|inv|dup)|
-                          exon\s?(?<exons>[0-9]+)\s?-exon\s?(?<otherexon>[0-9]+)\s?(?<mutationtype>del|inv|dup)/ix
+                          exon\s?(?<exons>[0-9]+)\s?-exon\s?(?<otherexon>[0-9]+)\s?(?<mutationtype>del|inv|dup)|
+                          (?<mutationtype>del|inv|dup)(.+ion)?\s?ex(on)?\s?(?<exons>[0-9]+(-[0-9]+)?)/ix
 
             GENOMICCHANGE_REGEX = /Chr(?<chromosome>\d+)\.hg
                                    (?<genome_build>\d+):g\.(?<effect>.+)/ix


### PR DESCRIPTION
## What?

During CASREF QA , Fiona and Jo have detected 5 incompatible teststatus and varpath class records for OXFORD (RTH) - 

- 1 record where teststatus is null and varpathclass is 4
- 1 record where teststatus is null and varpathclass is 5
- 3 records where teststatus is null and varpathclass is 3

## Why? 
Regex wasn't capturing the variants for these and hence not calling method to allocate the teststatus.

## How?
Fixed the regex , also corrected my understanding with help from @NImeson of cdna variants which were rightly constructed but my code was putting them in exemptions considering malformed.

## Testing?
Added test for impacted cases which are now rightly getting assigned teststatus along with varpathclass.
Also ran importer locally and could confirm counts are as expected and also query brings desired result - 

```
select * from restricted_variants where teststatusis null and variantpathclass in (3,4,5);
 pseudo_id1 | pseudo_id2 | codingdnasequencechange | gene | proteinimpact | servicereportidentifier | authoriseddate | variantpathclass | moleculartestingtype | genetictestscope | teststatus | variantlocation | exonintroncodonnumber | provider | sequencevarianttype | original_filename | raw_record | molecular_dataid 
------------+------------+-------------------------+------+---------------+-------------------------+----------------+------------------+----------------------+------------------+------------+-----------------+-----------------------+----------+---------------------+-------------------+------------+------------------
(0 rows)
```
