### PR TITLE
Feature/36725/birmingham status pathclass changes

### DIFF
--- a/lib/import/helpers/brca/providers/rq3/rq3_constants.rb
+++ b/lib/import/helpers/brca/providers/rq3/rq3_constants.rb
@@ -50,8 +50,8 @@ module Import
                          [0-9]+[ACGTdelinsup]+)/x
 
             NO_EVIDENCE_REGEX = /no evidence.*?[^cp]\.|no further.*?[^cp]\./i
-            NO_EVIDENCE_EXCEPTION_REGEX = /however the previously reported heterozygous variant c.* in the \S+ gene is
-                                           now considered a variant of unknown significance. /i
+            NO_EVIDENCE_EXCEPTION_REGEX = /however\sthe\spreviously\sreported\sheterozygous\svariant\sc.*\sin\sthe\s\S+
+            \sgene\sis\snow\sconsidered\sa\svariant\sof\sunknown\ssignificance/ix
             PROTEIN_REGEX = /p\.\(?(?<impact>.[a-z]+[0-9]+[a-z]+([^[:alnum:]][0-9]+)?|
             [a-z]+[0-9]+[^[:alnum:]])/ix
 

--- a/lib/import/helpers/brca/providers/rq3/rq3_constants.rb
+++ b/lib/import/helpers/brca/providers/rq3/rq3_constants.rb
@@ -50,6 +50,8 @@ module Import
                          [0-9]+[ACGTdelinsup]+)/x
 
             NO_EVIDENCE_REGEX = /no evidence.*?[^cp]\.|no further.*?[^cp]\./i
+            NO_EVIDENCE_EXCEPTION_REGEX = /however the previously reported heterozygous variant c.* in the \S+ gene is
+                                           now considered a variant of unknown significance. /i
             PROTEIN_REGEX = /p\.\(?(?<impact>.[a-z]+[0-9]+[a-z]+([^[:alnum:]][0-9]+)?|
             [a-z]+[0-9]+[^[:alnum:]])/ix
 

--- a/lib/import/helpers/brca/providers/rq3/rq3_helper.rb
+++ b/lib/import/helpers/brca/providers/rq3/rq3_helper.rb
@@ -103,14 +103,28 @@ module Import
               true_variant = @testresult.gsub(NO_EVIDENCE_REGEX, '')
               negativegenes = no_evidence.scan(BRCA_REGEX).flatten - true_variant.
                               scan(BRCA_REGEX).flatten
-              process_negative_genes(negativegenes)
-              @genotype.add_gene(unique_brca_genes_from(true_variant).join)
-              process_cdna(true_variant, @genotype)
-              process_protein_impact(true_variant, @genotype)
-              process_exon(true_variant, @genotype)
+              no_evidence_exception= @testresult.scan(NO_EVIDENCE_REGEX).join
+              if no_evidence_exception.size.positive?
+                process_no_evidence_exception(no_evidence_exception)
+              else
+                process_negative_genes(negativegenes)
+                @genotype.add_gene(unique_brca_genes_from(true_variant).join)
+                process_cdna(true_variant, @genotype)
+                process_protein_impact(true_variant, @genotype)
+                process_exon(true_variant, @genotype)
+                add_variantpathclass_uv_records(@genotype)
+                @genotypes.append(@genotype)
+              end 
+            end
+
+            def process_no_evidence_exception(testcolumn)
+              @genotype.add_gene(unique_brca_genes_from(testcolumn).join)
+              process_cdna(testcolumn, @genotype)
+              process_protein_impact(testcolumn, @genotype)
+              process_exon(testcolumn, @genotype)
               add_variantpathclass_uv_records(@genotype)
               @genotypes.append(@genotype)
-            end
+            end 
 
             def process_testresult_cdna_variants
               if (@testresult.scan(CDNA_REGEX).size > 1) ||

--- a/lib/import/helpers/brca/providers/rq3/rq3_helper.rb
+++ b/lib/import/helpers/brca/providers/rq3/rq3_helper.rb
@@ -103,7 +103,7 @@ module Import
               true_variant = @testresult.gsub(NO_EVIDENCE_REGEX, '')
               negativegenes = no_evidence.scan(BRCA_REGEX).flatten - true_variant.
                               scan(BRCA_REGEX).flatten
-              no_evidence_exception= @testresult.scan(NO_EVIDENCE_REGEX).join
+              no_evidence_exception= @testresult.scan(NO_EVIDENCE_EXCEPTION_REGEX).join
               if no_evidence_exception.size.positive?
                 process_no_evidence_exception(no_evidence_exception)
               else

--- a/lib/import/helpers/colorectal/providers/rq3/rq3_helper.rb
+++ b/lib/import/helpers/colorectal/providers/rq3/rq3_helper.rb
@@ -44,7 +44,7 @@ module Import
                 abnormal_genocolorectal = @genocolorectal.dup_colo
                 abnormal_genocolorectal.add_gene_colorectal(gene)
                 abnormal_genocolorectal.add_status(2)
-                abnormal_genocolorectal.add_variant_class(3) if @posnegtest == 'UV' 
+                add_variantpathclass_uv_records(abnormal_genocolorectal)       
                 abnormal_genocolorectal.add_variant_type(chromosomalvariant)
                 @genotypes.append(abnormal_genocolorectal)
               end
@@ -57,7 +57,7 @@ module Import
                 abnormal_genocolorectal.add_gene_location(cdna)
                 abnormal_genocolorectal.add_protein_impact(protein)
                 abnormal_genocolorectal.add_status(2)
-                abnormal_genocolorectal.add_variant_class(3) if @posnegtest == 'UV'     
+                add_variantpathclass_uv_records(abnormal_genocolorectal)    
                 @genotypes.append(abnormal_genocolorectal)
               end
             end
@@ -65,8 +65,8 @@ module Import
             def process_mutyh_single_cdna_variants
               @genocolorectal.add_gene_colorectal('MUTYH')
               @genocolorectal.add_gene_location(@testresult.scan(CDNA_REGEX).join)
-              @genocolorectal.add_status(2)           
-              @genocolorectal.add_variant_class(3) if @posnegtest == 'UV'               
+              @genocolorectal.add_status(2)       
+              add_variantpathclass_uv_records(@genocolorectal)                  
               if @testresult.scan(PROTEIN_REGEX).size.positive?
                 @genocolorectal.add_protein_impact(@testresult.scan(PROTEIN_REGEX).join)
               end
@@ -80,7 +80,7 @@ module Import
                 @genocolorectal.add_gene_colorectal('MUTYH')
                 @genocolorectal.add_gene_location('')
                 @genocolorectal.add_status(2)
-                @genocolorectal.add_variant_class(3) if @posnegtest == 'UV' 
+                add_variantpathclass_uv_records(@genocolorectal) 
                 @genotypes.append(@genocolorectal)
                 if full_screen?(@record)
                   negativegenes = @genelist - ['MUTYH']
@@ -112,7 +112,7 @@ module Import
                 @genocolorectal.add_gene_colorectal(unique_colorectal_genes_from(@testreport).join)
                 @genocolorectal.add_gene_location(@testreport.scan(CDNA_REGEX).join)
                 @genocolorectal.add_status(2)
-                @genocolorectal.add_variant_class(3) if @posnegtest == 'UV'
+                add_variantpathclass_uv_records(@genocolorectal) 
                 if @testreport.scan(PROTEIN_REGEX).size.positive?
                   @genocolorectal.add_protein_impact(@testreport.scan(PROTEIN_REGEX).join)
                 end
@@ -145,7 +145,7 @@ module Import
               end
               @genocolorectal.add_gene_location('')
               @genocolorectal.add_status(2)
-              @genocolorectal.add_variant_class(3) if @posnegtest == 'UV' 
+              add_variantpathclass_uv_records(@genocolorectal) 
               @genotypes.append(@genocolorectal)
             end
 
@@ -180,7 +180,7 @@ module Import
                 @genocolorectal.add_variant_type(varianttype)
                 @genocolorectal.add_gene_colorectal(colorectal_genes.join)
                 @genocolorectal.add_status(2)
-                @genocolorectal.add_variant_class(3) if @posnegtest == 'UV' 
+                add_variantpathclass_uv_records(@genocolorectal) 
                 @genotypes.append(@genocolorectal)
               elsif colorectal_genes.size > 1
                 genes = colorectal_genes_from(testcolumn)
@@ -205,6 +205,7 @@ module Import
                 testcolumn.scan(CHR_VARIANTS_REGEX)[1]
               end
             end
+
 
             def process_positive_records
               @logger.debug 'ABNORMAL TEST'
@@ -247,7 +248,7 @@ module Import
               end
               @genocolorectal.add_gene_location(@testresult.scan(CDNA_REGEX).join)
               @genocolorectal.add_status(2)
-              @genocolorectal.add_variant_class(3) if @posnegtest == 'UV'
+              add_variantpathclass_uv_records(@genocolorectal) 
               if @testresult.scan(PROTEIN_REGEX).size.positive?
                 @genocolorectal.add_protein_impact(@testresult.scan(PROTEIN_REGEX).join)
               end
@@ -262,6 +263,12 @@ module Import
                 negativegenes = @genelist - [unique_colorectal_genes_from(@testresult)[0]]
               end
               process_negative_genes(negativegenes)
+            end
+
+
+            def add_variantpathclass_uv_records(genotype_object)
+              return if @posnegtest.nil?
+              genotype_object.attribute_map['variantpathclass'] = 3 if @posnegtest == 'UV'
             end
 
             def sometimes_tested?(record)

--- a/lib/import/helpers/colorectal/providers/rq3/rq3_helper.rb
+++ b/lib/import/helpers/colorectal/providers/rq3/rq3_helper.rb
@@ -43,11 +43,9 @@ module Import
               positive_results.each do |gene, chromosomalvariant|
                 abnormal_genocolorectal = @genocolorectal.dup_colo
                 abnormal_genocolorectal.add_gene_colorectal(gene)
+                @abnormal_genocolorectal.add_status(2)
                 if @posnegtest == 'UV' 
-                  @abnormal_genocolorectal.add_status(10)
-                  @abnormal_genocolorectal.add_variant_class(3)
-                else
-                  @abnormal_genocolorectal.add_status(2)
+                  @abnormal_genocolorectal.add_variant_class(3)   
                 end 
                 abnormal_genocolorectal.add_variant_type(chromosomalvariant)
                 @genotypes.append(abnormal_genocolorectal)
@@ -60,12 +58,8 @@ module Import
                 abnormal_genocolorectal.add_gene_colorectal(gene)
                 abnormal_genocolorectal.add_gene_location(cdna)
                 abnormal_genocolorectal.add_protein_impact(protein)
-                if @posnegtest == 'UV' 
-                  @abnormal_genocolorectal.add_status(10)
-                  @abnormal_genocolorectal.add_variant_class(3)
-                else
-                  @abnormal_genocolorectal.add_status(2)
-                end 
+                @abnormal_genocolorectal.add_status(2)
+                @abnormal_genocolorectal.add_variant_class(3) if @posnegtest == 'UV'     
                 @genotypes.append(abnormal_genocolorectal)
               end
             end
@@ -73,12 +67,8 @@ module Import
             def process_mutyh_single_cdna_variants
               @genocolorectal.add_gene_colorectal('MUTYH')
               @genocolorectal.add_gene_location(@testresult.scan(CDNA_REGEX).join)
-              if @posnegtest == 'UV' 
-                @genocolorectal.add_status(10)
-                @genocolorectal.add_variant_class(3)
-              else
-                @genocolorectal.add_status(2)
-              end 
+              @genocolorectal.add_status(2)           
+              @genocolorectal.add_variant_class(3) if @posnegtest == 'UV'               
               if @testresult.scan(PROTEIN_REGEX).size.positive?
                 @genocolorectal.add_protein_impact(@testresult.scan(PROTEIN_REGEX).join)
               end
@@ -91,12 +81,8 @@ module Import
               else
                 @genocolorectal.add_gene_colorectal('MUTYH')
                 @genocolorectal.add_gene_location('')
-                if @posnegtest == 'UV' 
-                  @genocolorectal.add_status(10)
-                  @genocolorectal.add_variant_class(3)
-                else
-                  @genocolorectal.add_status(2)
-                end 
+                @genocolorectal.add_status(2)
+                @genocolorectal.add_variant_class(3) if @posnegtest == 'UV' 
                 @genotypes.append(@genocolorectal)
                 if full_screen?(@record)
                   negativegenes = @genelist - ['MUTYH']
@@ -127,12 +113,8 @@ module Import
               if genes_size == 1
                 @genocolorectal.add_gene_colorectal(unique_colorectal_genes_from(@testreport).join)
                 @genocolorectal.add_gene_location(@testreport.scan(CDNA_REGEX).join)
-                if @posnegtest == 'UV' 
-                  @genocolorectal.add_status(10)
-                  @genocolorectal.add_variant_class(3)
-                else
-                  @genocolorectal.add_status(2)
-                end 
+                @genocolorectal.add_status(2)
+                @genocolorectal.add_variant_class(3) if @posnegtest == 'UV'
                 if @testreport.scan(PROTEIN_REGEX).size.positive?
                   @genocolorectal.add_protein_impact(@testreport.scan(PROTEIN_REGEX).join)
                 end
@@ -164,12 +146,8 @@ module Import
                 process_negative_genes(negativegenes)
               end
               @genocolorectal.add_gene_location('')
-              if @posnegtest == 'UV' 
-                @genocolorectal.add_status(10)
-                @genocolorectal.add_variant_class(3)
-              else
-                @genocolorectal.add_status(2)
-              end 
+              @genocolorectal.add_status(2)
+              @genocolorectal.add_variant_class(3) if @posnegtest == 'UV' 
               @genotypes.append(@genocolorectal)
             end
 
@@ -203,12 +181,8 @@ module Import
                 varianttype = get_varianttype(testcolumn)
                 @genocolorectal.add_variant_type(varianttype)
                 @genocolorectal.add_gene_colorectal(colorectal_genes.join)
-                if @posnegtest == 'UV' 
-                  @genocolorectal.add_status(10)
-                  @genocolorectal.add_variant_class(3)
-                else
-                  @genocolorectal.add_status(2)
-                end 
+                @genocolorectal.add_status(2)
+                @genocolorectal.add_variant_class(3) if @posnegtest == 'UV' 
                 @genotypes.append(@genocolorectal)
               elsif colorectal_genes.size > 1
                 genes = colorectal_genes_from(testcolumn)
@@ -274,12 +248,8 @@ module Import
                 @genocolorectal.add_gene_colorectal(unique_colorectal_genes_from(@testresult)[0])
               end
               @genocolorectal.add_gene_location(@testresult.scan(CDNA_REGEX).join)
-              if @posnegtest == 'UV' 
-                @genocolorectal.add_status(10)
-                @genocolorectal.add_variant_class(3)
-              else
-                @genocolorectal.add_status(2)
-              end 
+              @genocolorectal.add_status(2)
+              @genocolorectal.add_variant_class(3) if @posnegtest == 'UV'
               if @testresult.scan(PROTEIN_REGEX).size.positive?
                 @genocolorectal.add_protein_impact(@testresult.scan(PROTEIN_REGEX).join)
               end

--- a/lib/import/helpers/colorectal/providers/rq3/rq3_helper.rb
+++ b/lib/import/helpers/colorectal/providers/rq3/rq3_helper.rb
@@ -43,10 +43,8 @@ module Import
               positive_results.each do |gene, chromosomalvariant|
                 abnormal_genocolorectal = @genocolorectal.dup_colo
                 abnormal_genocolorectal.add_gene_colorectal(gene)
-                @abnormal_genocolorectal.add_status(2)
-                if @posnegtest == 'UV' 
-                  @abnormal_genocolorectal.add_variant_class(3)   
-                end 
+                abnormal_genocolorectal.add_status(2)
+                abnormal_genocolorectal.add_variant_class(3) if @posnegtest == 'UV' 
                 abnormal_genocolorectal.add_variant_type(chromosomalvariant)
                 @genotypes.append(abnormal_genocolorectal)
               end
@@ -58,8 +56,8 @@ module Import
                 abnormal_genocolorectal.add_gene_colorectal(gene)
                 abnormal_genocolorectal.add_gene_location(cdna)
                 abnormal_genocolorectal.add_protein_impact(protein)
-                @abnormal_genocolorectal.add_status(2)
-                @abnormal_genocolorectal.add_variant_class(3) if @posnegtest == 'UV'     
+                abnormal_genocolorectal.add_status(2)
+                abnormal_genocolorectal.add_variant_class(3) if @posnegtest == 'UV'     
                 @genotypes.append(abnormal_genocolorectal)
               end
             end

--- a/lib/import/helpers/colorectal/providers/rq3/rq3_helper.rb
+++ b/lib/import/helpers/colorectal/providers/rq3/rq3_helper.rb
@@ -43,7 +43,12 @@ module Import
               positive_results.each do |gene, chromosomalvariant|
                 abnormal_genocolorectal = @genocolorectal.dup_colo
                 abnormal_genocolorectal.add_gene_colorectal(gene)
-                abnormal_genocolorectal.add_status(2)
+                if @posnegtest == 'UV' 
+                  @abnormal_genocolorectal.add_status(10)
+                  @abnormal_genocolorectal.add_variant_class(3)
+                else
+                  @abnormal_genocolorectal.add_status(2)
+                end 
                 abnormal_genocolorectal.add_variant_type(chromosomalvariant)
                 @genotypes.append(abnormal_genocolorectal)
               end
@@ -55,7 +60,12 @@ module Import
                 abnormal_genocolorectal.add_gene_colorectal(gene)
                 abnormal_genocolorectal.add_gene_location(cdna)
                 abnormal_genocolorectal.add_protein_impact(protein)
-                abnormal_genocolorectal.add_status(2)
+                if @posnegtest == 'UV' 
+                  @abnormal_genocolorectal.add_status(10)
+                  @abnormal_genocolorectal.add_variant_class(3)
+                else
+                  @abnormal_genocolorectal.add_status(2)
+                end 
                 @genotypes.append(abnormal_genocolorectal)
               end
             end
@@ -63,7 +73,12 @@ module Import
             def process_mutyh_single_cdna_variants
               @genocolorectal.add_gene_colorectal('MUTYH')
               @genocolorectal.add_gene_location(@testresult.scan(CDNA_REGEX).join)
-              @genocolorectal.add_status(2)
+              if @posnegtest == 'UV' 
+                @genocolorectal.add_status(10)
+                @genocolorectal.add_variant_class(3)
+              else
+                @genocolorectal.add_status(2)
+              end 
               if @testresult.scan(PROTEIN_REGEX).size.positive?
                 @genocolorectal.add_protein_impact(@testresult.scan(PROTEIN_REGEX).join)
               end
@@ -76,7 +91,12 @@ module Import
               else
                 @genocolorectal.add_gene_colorectal('MUTYH')
                 @genocolorectal.add_gene_location('')
-                @genocolorectal.add_status(2)
+                if @posnegtest == 'UV' 
+                  @genocolorectal.add_status(10)
+                  @genocolorectal.add_variant_class(3)
+                else
+                  @genocolorectal.add_status(2)
+                end 
                 @genotypes.append(@genocolorectal)
                 if full_screen?(@record)
                   negativegenes = @genelist - ['MUTYH']
@@ -107,7 +127,12 @@ module Import
               if genes_size == 1
                 @genocolorectal.add_gene_colorectal(unique_colorectal_genes_from(@testreport).join)
                 @genocolorectal.add_gene_location(@testreport.scan(CDNA_REGEX).join)
-                @genocolorectal.add_status(2)
+                if @posnegtest == 'UV' 
+                  @genocolorectal.add_status(10)
+                  @genocolorectal.add_variant_class(3)
+                else
+                  @genocolorectal.add_status(2)
+                end 
                 if @testreport.scan(PROTEIN_REGEX).size.positive?
                   @genocolorectal.add_protein_impact(@testreport.scan(PROTEIN_REGEX).join)
                 end
@@ -139,7 +164,12 @@ module Import
                 process_negative_genes(negativegenes)
               end
               @genocolorectal.add_gene_location('')
-              @genocolorectal.add_status(2)
+              if @posnegtest == 'UV' 
+                @genocolorectal.add_status(10)
+                @genocolorectal.add_variant_class(3)
+              else
+                @genocolorectal.add_status(2)
+              end 
               @genotypes.append(@genocolorectal)
             end
 
@@ -173,7 +203,12 @@ module Import
                 varianttype = get_varianttype(testcolumn)
                 @genocolorectal.add_variant_type(varianttype)
                 @genocolorectal.add_gene_colorectal(colorectal_genes.join)
-                @genocolorectal.add_status(2)
+                if @posnegtest == 'UV' 
+                  @genocolorectal.add_status(10)
+                  @genocolorectal.add_variant_class(3)
+                else
+                  @genocolorectal.add_status(2)
+                end 
                 @genotypes.append(@genocolorectal)
               elsif colorectal_genes.size > 1
                 genes = colorectal_genes_from(testcolumn)
@@ -201,7 +236,6 @@ module Import
 
             def process_positive_records
               @logger.debug 'ABNORMAL TEST'
-              @genocolorectal.add_variant_class(3) if @posnegtest.upcase == 'UV'
               if @testresult.scan(/MYH/).size.positive?
                 process_mutyh_specific_variants
               elsif colorectal_genes_from_test_result.empty?
@@ -240,7 +274,12 @@ module Import
                 @genocolorectal.add_gene_colorectal(unique_colorectal_genes_from(@testresult)[0])
               end
               @genocolorectal.add_gene_location(@testresult.scan(CDNA_REGEX).join)
-              @genocolorectal.add_status(2)
+              if @posnegtest == 'UV' 
+                @genocolorectal.add_status(10)
+                @genocolorectal.add_variant_class(3)
+              else
+                @genocolorectal.add_status(2)
+              end 
               if @testresult.scan(PROTEIN_REGEX).size.positive?
                 @genocolorectal.add_protein_impact(@testresult.scan(PROTEIN_REGEX).join)
               end

--- a/test/lib/import/brca/providers/birmingham/birmingham_handler_newformat_test.rb
+++ b/test/lib/import/brca/providers/birmingham/birmingham_handler_newformat_test.rb
@@ -191,6 +191,22 @@ class BirminghamHandlerNewformatTest < ActiveSupport::TestCase
     assert_nil genotypes[1].attribute_map['proteinimpact']
   end
 
+  test 'process_testresult_no_evidence_exception' do
+    cdna_noevidence_exception_record = build_raw_record('pseudo_id1' => 'bob')
+    cdna_noevidence_exception_record.raw_fields['teststatus'] = 'Previous molecular analysis has shown no evidence of the familial variant, however the previously reported heterozygous variant c.206-1G>T in the BRIP1 gene is now considered a variant of unknown significance'
+    cdna_noevidence_exception_record.raw_fields['report'] = "Variants classified according to ACGS Best Practice Guidelines for Variant Classification in Rare Disease 2020."
+    cdna_noevidence_exception_record.raw_fields['overall2'] = 'UV'
+    processor = variant_processor_for(cdna_noevidence_exception_record)
+    @handler.process_genetictestscope(@genotype, cdna_noevidence_exception_record)
+    genotypes = processor.process_variants_from_report
+    assert_equal 1, genotypes.size
+    assert_equal 590, genotypes[0].attribute_map['gene']
+    assert_equal 2, genotypes[0].attribute_map['teststatus']
+    assert_equal 3, genotypes[0].attribute_map['variantpathclass']
+    assert_equal 'c.206-1G>T', genotypes[0].attribute_map['codingdnasequencechange']
+    assert_nil genotypes[0].attribute_map['proteinimpact']
+  end
+
   test 'process_testresult_multiple_cdna_variant' do
     multi_cdna_variants_record = build_raw_record('pseudo_id1' => 'bob')
     multi_cdna_variants_record.raw_fields['teststatus'] = 'Molecular analysis shows 5075G>A (M1652I) sequence variant in BRCA1 and 8410G>A (V2728I) sequence variant in BRCA2'

--- a/test/lib/import/colorectal/providers/birmingham/birmingham_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/birmingham/birmingham_handler_colorectal_test.rb
@@ -85,6 +85,27 @@ class BirminghamHandlerColorectalTest < ActiveSupport::TestCase
     assert_equal 2850, genocolorectals[0].attribute_map['gene']
   end
 
+  test 'process_testresult_single_VUS_variant' do
+    cdna_vus_record = build_raw_record('pseudo_id1' => 'bob')
+    cdna_vus_record.raw_fields['teststatus'] = 'Heterozygous missense variant of uncertain significance c.1309_1311del p.(His437del) identified in the MSH6 gene.'
+    cdna_vus_record.raw_fields['report'] = 'MLPA analysis of all MSH6, MLH1 and PMS2 exons to detect whole exon deletions/duplications.'
+    cdna_vus_record.raw_fields['overall2'] = 'UV'
+    processor = variant_processor_for(cdna_vus_record)
+    genocolorectals = processor.process_variants_from_report
+    assert_equal 3, genocolorectals.size
+    assert_equal 2744, genocolorectals[0].attribute_map['gene']
+    assert_equal 1, genocolorectals[0].attribute_map['teststatus']
+    assert_nil genocolorectals[0].attribute_map['variantpathclass']
+    assert_equal 3394, genocolorectals[1].attribute_map['gene']
+    assert_equal 1, genocolorectals[1].attribute_map['teststatus']
+    assert_nil genocolorectals[1].attribute_map['variantpathclass']
+    assert_equal 2808, genocolorectals[2].attribute_map['gene']
+    assert_equal 2, genocolorectals[2].attribute_map['teststatus']
+    assert_equal 3, genocolorectals[2].attribute_map['variantpathclass']
+    assert_equal 'c.1309_1311delp', genocolorectals[2].attribute_map['codingdnasequencechange']
+    assert_equal 'p.His437del', genocolorectals[2].attribute_map['proteinimpact']
+  end
+
   test 'process_multiple_variants_single_gene' do
     multiple_cdna_record = build_raw_record('pseudo_id1' => 'bob')
     multiple_cdna_record.raw_fields['teststatus'] = 'Heterozygous missense variant (c.1688G>T; p.Arg563Leu) identified in exon 11 of the PMS2 gene and a heterozygous intronic variant (c.251-20T>G) in intron 4 of the PMS2 gene.'


### PR DESCRIPTION
**What?**
During the CASREF QA , 34  records with incompatible teststatus and varpath class were identified for Birmingham (RQ3) -

33 records where teststatus is 1 and varpathclass is 3
1 record where teststatus is null and varpathclass is 3

**Why?**
For the 33 records, the importer was setting var path class 3 before duplicating the record for all genes in a panel, therefore the var path class gets duplicated along with it so even genes without a variant will be assigned path class 3 .

For the 1 record - this record was matching a "NO EVIDENCE' regex when there was additional information in there however there was also a note of a variant reclassification in there as well which was being filtered out 

**How?**
Removed varpath assigning from the start of variant processing and now only assigning varpath class of 3 when a teststatus of 2 is assigned and IF 'UV' is present in the overall2 field.

Added an additional exception regex to the 'NO EVIDENCE' regex to account for this scenario

**Testing?**
Tests added to both BRCA and CRC handler test suites and variants counts performed and compared to those before changes were made. 

```
mbis_development=# select * from restricted_variants where teststatus = 1 and variantpathclass = 3;
 pseudo_id1 | pseudo_id2 | codingdnasequencechange | gene | proteinimpact | servicereportidentifier | authoriseddate | variantpathclass | moleculartestingtype | genetictestscope | teststatus | exonintroncodonnumber | provider | sequencevarianttype | original_filename | raw_record | molecular_dataid 
------------+------------+-------------------------+------+---------------+-------------------------+----------------+------------------+----------------------+------------------+------------+-----------------------+----------+---------------------+-------------------+------------+------------------
(0 rows)
```

```
mbis_development=# select * from restricted_variants where teststatus is null and variantpathclass = 3;
 pseudo_id1 | pseudo_id2 | codingdnasequencechange | gene | proteinimpact | servicereportidentifier | authoriseddate | variantpathclass | moleculartestingtype | genetictestscope | teststatus | exonintroncodonnumber | provider | sequencevarianttype | original_filename | raw_record | molecular_dataid 
------------+------------+-------------------------+------+---------------+-------------------------+----------------+------------------+----------------------+------------------+------------+-----------------------+----------+---------------------+-------------------+------------+------------------
(0 rows)

```