### PR TITLE
Interim support for cause of death 1d exports

### DIFF
--- a/app/models/pseudo/death.rb
+++ b/app/models/pseudo/death.rb
@@ -33,7 +33,8 @@ module Pseudo
     #
     # In LEDR, cause codes have moved from being in a mixture of lineno9f_... / lineno9_... fields,
     # and cod10rf_... / cod10r_... fields, to exclusively cod10rf_... / cod10r_... fields.
-    def matched_cause_codes(i)
+    # TODO: Change parameter (i) to allow letters, to support cause 1d extracts
+    def matched_cause_codes(i) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Naming/MethodParameterName
       raise 'Invalid index' unless (1..6).include?(i)
 
       # lineno values are always 1-6
@@ -41,10 +42,15 @@ module Pseudo
         cod10r = death_data.send("cod10rf_#{j}") || death_data.send("cod10r_#{j}")
         line = death_data.send("lineno9f_#{j}") || death_data.send("lineno9_#{j}")
         # More recent deaths have inconsistently back-ported lineno values from cod10r values
-        line = nil if cod10r && line && death_data.dor.to_i >= 20180206 #  diffs
+        line = nil if cod10r && line && death_data.dor.to_i >= 20180206 #  diffs # rubocop:disable Style/NumericLiterals
+        # Temporarily treat cause 1d as cause 1c for cancer deaths extracts, and warn in the logs,
+        # until a new field is added to the extract.
+        if i == 3 && cod10r == 'f' && DeathData::COD10R_TO_LINENO9['f'] == 3
+          logger.warn("#{self.class.name} export warning: treating cause of death 1d as cause " \
+                      "1c in e_batchid #{e_batch_id} for matched_cause_codes(#{i}) with " \
+                      "cod10rf_#{j}/cod10r_#{j} = #{cod10r.inspect}")
+        end
         # Prefer old lineno9 value, for continuity, and because it's more finegrained
-        raise 'New death cause 1d not yet supported' if cod10r == 'f'
-
         next unless (line || DeathData::COD10R_TO_LINENO9[cod10r]) == i
 
         multiple_cause_code(j)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -239,6 +239,7 @@ ActiveRecord::Schema.define(version: 2018_12_21_110625) do
     t.string "codt_3"
     t.string "codt_4"
     t.string "codt_5"
+    t.string "codt_6"
     t.string "ctydpod"
     t.string "ctypod"
     t.string "dester"

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1384,7 +1384,8 @@ CREATE TABLE public.death_data (
     ccg9pod character varying,
     ccg9r character varying,
     gor9r character varying,
-    ward9r character varying
+    ward9r character varying,
+    codt_6 character varying
 );
 
 

--- a/lib/export/cancer_death_common.rb
+++ b/lib/export/cancer_death_common.rb
@@ -10,7 +10,7 @@ module Export
   # all: Everything, including repeats of the same patient, and patients with no causes of death
   # cara: New congenital anomaly deaths, cf. https://ncr.plan.io/issues/15123
   # cara_all: All congenital anomaly deaths
-  class CancerDeathCommon < DeathFile
+  class CancerDeathCommon < DeathFile # rubocop:disable Metrics/ClassLength
     CARA_PATTERN = /\A(D215\z|D821|D1810|E7030|P350|P351|P371|P358|P832|K070|
           Q(?!038\z|039\z|0461\z|0780\z|0782\z|101\z|102\z|103\z|105\z|135\z|170\z|171\z|172\z|
               173\z|174\z|
@@ -78,7 +78,8 @@ module Export
       'occupation_mother' => 'occmt', 'dateofdeath' => 'dod', 'dateofdeath_text' => nil,
       'placeofdeath' => 'podt', 'ons_text1a' => 'codt_codfft_1_255',
       'ons_text1b' => 'codt_codfft_2_255',
-      'ons_text1c' => 'codt_codfft_3_255', 'ons_text2' => 'codt_codfft_4_255',
+      'ons_text1c' => 'codt_codfft_3_codt_6_255', # Combine CODT_3 and CODT_6 (cause 1c + 1d)
+      'ons_text2' => 'codt_codfft_4_255',
       'ons_text' => 'codt_codfft_5_255extra',
       'ons_code1a' => 'matched_cause_code_1', 'ons_code1b' => 'matched_cause_code_2',
       'ons_code1c' => 'matched_cause_code_3', 'ons_code2' => 'matched_cause_code_4',

--- a/test/integration/project_amendments_test.rb
+++ b/test/integration/project_amendments_test.rb
@@ -17,12 +17,12 @@ class ProjectAmendmentsTest < ActionDispatch::IntegrationTest
 
       assert has_no_link?(href: new_project_project_amendment_path(project))
       assert has_selector?(dom_id)
-      assert has_text?('Requested at')
-      assert has_text?('Amendment approved date')
+      assert_text('Requested at')
+      assert_text('Amendment approved date')
 
       within(dom_id) do
-        assert has_text?(amendment.requested_at.to_s(:ui))
-        assert has_text?(amendment.amendment_approved_date.to_s(:ui))
+        assert_text(amendment.requested_at.to_s(:ui))
+        assert_text(amendment.amendment_approved_date.to_s(:ui))
         assert has_link?(href: project_amendment_path(amendment),         title: 'Details')
         assert has_no_link?(href: edit_project_amendment_path(amendment), title: 'Edit')
         assert has_no_link?(href: project_amendment_path(amendment),      title: 'Delete')
@@ -52,7 +52,7 @@ class ProjectAmendmentsTest < ActionDispatch::IntegrationTest
       click_button('Create Amendment')
 
       assert_current_path project_path(project)
-      assert has_text?('Amendment created successfully')
+      assert_text('Amendment created successfully')
       assert has_selector?('#projectAmendments', visible: true)
     end
     assert_equal 1, project.reload.amendment_number
@@ -85,7 +85,7 @@ class ProjectAmendmentsTest < ActionDispatch::IntegrationTest
         click_button('Update Amendment')
 
         assert_current_path project_path(project)
-        assert has_text?('Amendment updated successfully')
+        assert_text('Amendment updated successfully')
         assert has_selector?('#projectAmendments', visible: true)
       end
     end
@@ -113,7 +113,7 @@ class ProjectAmendmentsTest < ActionDispatch::IntegrationTest
       assert_current_path project_path(project)
     end
 
-    assert has_text?('Amendment destroyed successfully')
+    assert_text('Amendment destroyed successfully')
     assert has_selector?('#projectAmendments', visible: true)
   end
 
@@ -138,7 +138,7 @@ class ProjectAmendmentsTest < ActionDispatch::IntegrationTest
     visit edit_project_amendment_path(amendment)
 
     assert_no_current_path project_amendment_path(amendment)
-    assert has_text?('You are not authorized to access this page.')
+    assert_text('You are not authorized to access this page.')
   end
 
   test 'amendments without attachments should block transition to DPIA_START' do
@@ -156,8 +156,8 @@ class ProjectAmendmentsTest < ActionDispatch::IntegrationTest
       end
     end
 
-    assert has_text?('This project cannot move to "DPIA" for 1 reason')
-    assert has_text?('no amendment document attached')
+    assert_text('This project cannot move to "DPIA" for 1 reason')
+    assert_text('no amendment document attached')
     assert has_button?('Begin DPIA', disabled: true)
 
     click_link 'Amendments'

--- a/test/integration/project_assignments_test.rb
+++ b/test/integration/project_assignments_test.rb
@@ -23,7 +23,7 @@ class ProjectAssignmentsTest < ActionDispatch::IntegrationTest
     end
 
     assert_current_path project_path(@project)
-    assert has_text?('Project assigned successfully')
+    assert_text('Project assigned successfully')
     assert has_select?('Assigned User')
     assert has_no_selector?('dt', text: 'Assigned User')
   end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -4,6 +4,15 @@ require 'test_helper'
 module IntegrationTestHelper
   extend ActiveSupport::Concern
 
+  included do
+    # Ensure that tests do not leave extra windows open, polluting other tests.
+    teardown do
+      next if windows.count <= 1
+
+      raise "Error: test left extra windows open: windows.count = #{windows.count}"
+    end
+  end
+
   # Manually wait for AJAX requests in integration tests, for clarity.
   def wait_for_ajax
     started_waiting_at = Time.current

--- a/test/lib/export/cancer_death_common_test.rb
+++ b/test/lib/export/cancer_death_common_test.rb
@@ -1,17 +1,144 @@
 require 'test_helper'
 
-class CancerDeathCommonTest < ActiveSupport::TestCase
-  test 'match CARA ICD codes' do
-    should_match = %w[D821 Q012 Q262 Q605]
-    should_match.each do |icd|
-      assert_match Export::CancerDeathCommon::CARA_PATTERN, icd
+# rubocop:disable Naming/VariableNumber
+module Export
+  class CancerDeathCommonTest < ActiveSupport::TestCase
+    def setup
+      @nhsnumber = '9999999468'
+      @birthdate = '1925-01-27'
+      @postcode = 'PE133AB'
+      @demographics = { 'nhsnumber' => @nhsnumber, 'birthdate' => @birthdate,
+                        'postcode' => @postcode }
+      @key = 'unittest_encrypt'
+      ENV['MBIS_KEK'] = 'test'
+      @keystore = Pseudo::KeyStoreLocal.new(Pseudo::KeyBundle.new)
+      Pseudo::Ppatient.keystore = @keystore
     end
-  end
 
-  test 'reject non-CARA ICD codes' do
-    should_reject = %w[A020 D823 P524 Q250 Q038 Q039 Q336 Q658 Q673] + ['']
-    should_reject.each do |icd|
-      assert_no_match Export::CancerDeathCommon::CARA_PATTERN, icd
+    # Helper constructor for a patient with codt, icd and cod10r fields but no codfft
+    # (LEDR style, with no cause 1d)
+    def codt_icd_ppat_and_fields_without_cause1d
+      fields_no_demog = { codt_1: 'Cause 1' * 86, codt_2: '222', codt_3: '333',
+                          codt_4: '4' * 75, codt_5: 'cause 5',
+                          icd_1: 'A01', cod10r_1: 'a',
+                          icd_2: 'B01', cod10r_2: 'b',
+                          icd_3: 'C01', cod10r_3: 'c',
+                          icd_4: 'D01', cod10r_4: 'd',
+                          icd_5: 'E01', cod10r_5: 'e',
+                          icd_6: 'E02', cod10r_6: 'e',
+                          icd_7: 'A002', cod10r_7: 'a',
+                          icd_8: 'B002', cod10r_8: 'b',
+                          icd_9: 'C002', cod10r_9: 'c',
+                          icd_10: 'D002', cod10r_10: 'd',
+                          icd_11: 'E003', cod10r_11: 'e',
+                          icd_12: 'E004', cod10r_12: 'e',
+                          icd_13: 'X01', cod10r_13: '11', # historic ONS_CODE field
+                          icd_14: 'X002', cod10r_14: '12', # historic ONS_CODE field
+                          icdu: 'U01',
+                          icdsc: 'S01' }
+      ppat = build_death_record(fields_no_demog)
+      [ppat, fields_no_demog]
+    end
+
+    # Helper constructor for a patient with codt, icd and cod10r fields but no codfft
+    # (LEDR style, with cause 1d)
+    def codt_icd_ppat_and_fields_with_cause1d
+      fields_no_demog = { codt_1: 'Cause 1' * 86, codt_2: '222', codt_3: '333',
+                          codt_4: '4' * 75, codt_5: 'cause 5', codt_6: 'cause 1d',
+                          icd_1: 'A01', cod10r_1: 'a',
+                          icd_2: 'B01', cod10r_2: 'b',
+                          icd_3: 'C01', cod10r_3: 'c',
+                          icd_4: 'D01', cod10r_4: 'd',
+                          icd_5: 'E01', cod10r_5: 'e',
+                          icd_6: 'F01', cod10r_6: 'f',
+                          icd_7: 'A002', cod10r_7: 'a',
+                          icd_8: 'B002', cod10r_8: 'b',
+                          icd_9: 'C002', cod10r_9: 'c',
+                          icd_10: 'D002', cod10r_10: 'd',
+                          icd_11: 'E002', cod10r_11: 'e',
+                          icd_12: 'F002', cod10r_12: 'f',
+                          icd_13: 'X01', cod10r_13: '11', # historic ONS_CODE field
+                          icd_14: 'X002', cod10r_14: '12', # historic ONS_CODE field
+                          icdu: 'U01',
+                          icdsc: 'S01' }
+      ppat = build_death_record(fields_no_demog)
+      [ppat, fields_no_demog]
+    end
+
+    def build_death_record(fields_no_demog)
+      rawtext = nil # No rawtext preserved for death data
+      ppat = Pseudo::Death.initialize_from_demographics(@key, @demographics, rawtext, e_batch: @e_batch)
+      ppat.build_death_data(fields_no_demog)
+      ppat
+    end
+
+    def extract_cancer_death_csv(ppats)
+      ppat_scope = Pseudo::Ppatient.where(id: ppats.collect(&:id))
+      outdata = Tempfile.create do |outfile|
+        extractor = CancerDeathWeekly.new(outfile.path, 'PSDEATH', ppat_scope, 'all')
+        extractor.export
+        outfile.read
+      end
+      CSV.parse(outdata, headers: true)
+    end
+
+    test 'match CARA ICD codes' do
+      should_match = %w[D821 Q012 Q262 Q605]
+      should_match.each do |icd|
+        assert_match Export::CancerDeathCommon::CARA_PATTERN, icd
+      end
+    end
+
+    test 'reject non-CARA ICD codes' do
+      should_reject = %w[A020 D823 P524 Q250 Q038 Q039 Q336 Q658 Q673] + ['']
+      should_reject.each do |icd|
+        assert_no_match Export::CancerDeathCommon::CARA_PATTERN, icd
+      end
+    end
+
+    test 'should extract cancer death record fields for deaths with no cause 1d' do
+      ppat, fields = codt_icd_ppat_and_fields_without_cause1d
+      ppat.save(validate: false)
+      outcsv = extract_cancer_death_csv([ppat])
+      assert_equal(1, outcsv.size)
+      row = outcsv[0].to_h
+      assert_equal(34, row.size)
+
+      assert_equal(fields[:codt_1], row['ONS_TEXT1A'], 'ONS_TEXT1A')
+      assert_equal(fields[:codt_2], row['ONS_TEXT1B'], 'ONS_TEXT1B')
+      assert_equal(fields[:codt_3], row['ONS_TEXT1C'], 'ONS_TEXT1C')
+      assert_equal(fields[:codt_4], row['ONS_TEXT2'], 'ONS_TEXT2')
+      assert_equal(fields[:codt_5], row['ONS_TEXT'], 'ONS_TEXT')
+      assert_equal('A01,A002', row['ONS_CODE1A'], 'ONS_CODE1A')
+      assert_equal('B01,B002', row['ONS_CODE1B'], 'ONS_CODE1B')
+      assert_equal('C01,C002', row['ONS_CODE1C'], 'ONS_CODE1C')
+      assert_equal('D01,E01,E02,D002,E003,E004', row['ONS_CODE2'], 'ONS_CODE2')
+      assert_equal('X01,X002', row['ONS_CODE'], 'ONS_CODE')
+      assert_equal('U01', row['DEATHCAUSECODE_UNDERLYING'], 'DEATHCAUSECODE_UNDERLYING')
+      assert_equal('S01', row['DEATHCAUSECODE_SIGNIFICANT'], 'DEATHCAUSECODE_SIGNIFICANT')
+    end
+
+    test 'should extract cancer death record fields for deaths with cause 1d' do
+      ppat, fields = codt_icd_ppat_and_fields_with_cause1d
+      ppat.save(validate: false)
+      outcsv = extract_cancer_death_csv([ppat])
+      assert_equal(1, outcsv.size)
+      row = outcsv[0].to_h
+      assert_equal(34, row.size)
+
+      assert_equal(fields[:codt_1], row['ONS_TEXT1A'], 'ONS_TEXT1A')
+      assert_equal(fields[:codt_2], row['ONS_TEXT1B'], 'ONS_TEXT1B')
+      assert_equal("#{fields[:codt_3]}, #{fields[:codt_6]}", row['ONS_TEXT1C'], 'ONS_TEXT1C')
+      assert_equal(fields[:codt_4], row['ONS_TEXT2'], 'ONS_TEXT2')
+      assert_equal(fields[:codt_5], row['ONS_TEXT'], 'ONS_TEXT')
+      assert_equal('A01,A002', row['ONS_CODE1A'], 'ONS_CODE1A')
+      assert_equal('B01,B002', row['ONS_CODE1B'], 'ONS_CODE1B')
+      assert_equal('C01,F01,C002,F002', row['ONS_CODE1C'], 'ONS_CODE1C')
+      assert_equal('D01,E01,D002,E002', row['ONS_CODE2'], 'ONS_CODE2')
+      assert_equal('X01,X002', row['ONS_CODE'], 'ONS_CODE')
+      assert_equal('U01', row['DEATHCAUSECODE_UNDERLYING'], 'DEATHCAUSECODE_UNDERLYING')
+      assert_equal('S01', row['DEATHCAUSECODE_SIGNIFICANT'], 'DEATHCAUSECODE_SIGNIFICANT')
     end
   end
 end
+# rubocop:enable Naming/VariableNumber


### PR DESCRIPTION
This PR adds interim support for cause of death 1d exports, until the export formats can be changed. [NDRS2-2014]

* Cancer death extract should temporarily treat death cause 1d as part of 1c.

The longer-term fix is to change the cancer death extract to add another field for cause of death 1(d). Any affected death records should then be re-extracted.