### PR TITLE
Ignore bootstrap version 3 warning [NDRS2-1676]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,9 @@ jobs:
       with:
         bundler-cache: true
     - name: Audit the bundle
-      run: bundle exec bundle-audit check --update
+      # Ignore bootstrap version 3 warning: https://nhsd-jira.digital.nhs.uk/browse/NDRS2-1676
+      run: bundle exec bundle-audit check --update --ignore CVE-2024-6484
+      # run: bundle exec bundle-audit check --update
 
   # A utility job upon which Branch Protection can depend,
   # thus remaining agnostic of the matrix.


### PR DESCRIPTION
This PR ignores the bootstrap 3 `bundle audit` security warning on the `bootstrap-sass` gem: this is an accepted risk that we plan to fix, but which will need substantial work. Flagging this as an error on every PR is just noise at this point, and could obscure other, new security issues.