### PR TITLE
Feature/36720/royal marsden crc importer teststatus 10

### DIFF
--- a/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
@@ -100,26 +100,6 @@ module Import
             end
           end
 
-          # def process_teststatus(genocolorectal, record)
-          #   teststatus = record.raw_fields['teststatus'] unless record.raw_fields['teststatus'].nil?
-          #   if /NO PATHOGENIC (VARIANT|DEL\/DUP) IDENTIFIED/.match(teststatus) ||
-          #      /No mutation detected/.match(teststatus)
-          #     genocolorectal.add_status(1)
-          #   elsif /non-pathogenic variant detected/.match(teststatus)
-          #     genocolorectal.add_status(10)
-          #     genocolorectal.add_variant_class(6) #Ad-hoc variant path class for when we know it is class1/2 but can't distinguish.
-          #   elsif /Fail/i.match(teststatus)
-          #     genocolorectal.add_status(9)
-          #   elsif /c\..+/.match(teststatus) ||
-          #         /Deletion*/.match(teststatus) ||
-          #         /Duplication*/.match(teststatus) ||
-          #         /Exon*/i.match(teststatus)
-          #         genocolorectal.add_status(2)
-          #   else
-          #     @logger.debug 'UNABLE TO DETERMINE TESTSTATUS'
-          #   end
-          # end
-
           def process_teststatus(genocolorectal, record)
             teststatus = record.raw_fields['teststatus'] unless record.raw_fields['teststatus'].nil?
             case teststatus

--- a/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
@@ -103,9 +103,10 @@ module Import
           def process_teststatus(genocolorectal, record)
             teststatus = record.raw_fields['teststatus'] unless record.raw_fields['teststatus'].nil?
             if /NO PATHOGENIC (VARIANT|DEL\/DUP) IDENTIFIED/.match(teststatus) ||
-               /non-pathogenic variant detected/.match(teststatus) ||
                /No mutation detected/.match(teststatus)
               genocolorectal.add_status(1)
+            elsif /non-pathogenic variant detected/.match(teststatus)
+              genocolorectal.add_status(10)
             elsif /Fail/i.match(teststatus)
               genocolorectal.add_status(9)
             elsif /c\..+/.match(teststatus) ||

--- a/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
@@ -100,24 +100,43 @@ module Import
             end
           end
 
+          # def process_teststatus(genocolorectal, record)
+          #   teststatus = record.raw_fields['teststatus'] unless record.raw_fields['teststatus'].nil?
+          #   if /NO PATHOGENIC (VARIANT|DEL\/DUP) IDENTIFIED/.match(teststatus) ||
+          #      /No mutation detected/.match(teststatus)
+          #     genocolorectal.add_status(1)
+          #   elsif /non-pathogenic variant detected/.match(teststatus)
+          #     genocolorectal.add_status(10)
+          #     genocolorectal.add_variant_class(6) #Ad-hoc variant path class for when we know it is class1/2 but can't distinguish.
+          #   elsif /Fail/i.match(teststatus)
+          #     genocolorectal.add_status(9)
+          #   elsif /c\..+/.match(teststatus) ||
+          #         /Deletion*/.match(teststatus) ||
+          #         /Duplication*/.match(teststatus) ||
+          #         /Exon*/i.match(teststatus)
+          #         genocolorectal.add_status(2)
+          #   else
+          #     @logger.debug 'UNABLE TO DETERMINE TESTSTATUS'
+          #   end
+          # end
+
           def process_teststatus(genocolorectal, record)
             teststatus = record.raw_fields['teststatus'] unless record.raw_fields['teststatus'].nil?
-            if /NO PATHOGENIC (VARIANT|DEL\/DUP) IDENTIFIED/.match(teststatus) ||
-               /No mutation detected/.match(teststatus)
+            case teststatus
+            when /NO PATHOGENIC (VARIANT|DEL\/DUP) IDENTIFIED/ || /No mutation detected/
               genocolorectal.add_status(1)
-            elsif /non-pathogenic variant detected/.match(teststatus)
+            when /non-pathogenic variant detected/
               genocolorectal.add_status(10)
-            elsif /Fail/i.match(teststatus)
+              genocolorectal.add_variant_class(6) #Ad-hoc variant path class for when we know it is class1/2 but can't distinguish.
+            when /Fail/i
               genocolorectal.add_status(9)
-            elsif /c\..+/.match(teststatus) ||
-                  /Deletion*/.match(teststatus) ||
-                  /Duplication*/.match(teststatus) ||
-                  /Exon*/i.match(teststatus)
-                  genocolorectal.add_status(2)
-            else
+            when /c\..+/ || /Deletion*/ || /Duplication*/ || /Exon*/i
+              genocolorectal.add_status(2)
+            else 
               @logger.debug 'UNABLE TO DETERMINE TESTSTATUS'
             end
-          end
+          end  
+
 
           def process_variant(genocolorectal, record)
             variant = record.raw_fields['teststatus'] unless record.raw_fields['teststatus'].nil?

--- a/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
@@ -95,6 +95,9 @@ module Import
 
             if !varpathclass.nil? && !varpathclass.empty? && VARIANT_PATH_CLASS_COLO[varpathclass]
               genocolorectal.add_variant_class(VARIANT_PATH_CLASS_COLO[varpathclass.downcase])
+            elsif varpathclass.nil? && varpathclass.empty? 
+              && record.raw_fields['teststatus'].match(/non-pathogenic variant detected/)
+              genocolorectal.add_variant_class(6) #Ad-hoc variant path class for when we know it is class1/2 but can't distinguish.
             else
               @logger.debug 'NO VARIANTPATHCLASS DETECTED'
             end
@@ -107,7 +110,6 @@ module Import
               genocolorectal.add_status(1)
             when /non-pathogenic variant detected/
               genocolorectal.add_status(10)
-              genocolorectal.add_variant_class(6) #Ad-hoc variant path class for when we know it is class1/2 but can't distinguish.
             when /Fail/i
               genocolorectal.add_status(9)
             when /c\..+/ || /Deletion*/ || /Duplication*/ || /Exon*/i

--- a/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
@@ -95,20 +95,24 @@ module Import
 
             if !varpathclass.nil? && !varpathclass.empty? && VARIANT_PATH_CLASS_COLO[varpathclass]
               genocolorectal.add_variant_class(VARIANT_PATH_CLASS_COLO[varpathclass.downcase])
-            elsif varpathclass.nil? && varpathclass.empty? 
-              && record.raw_fields['teststatus'].match(/non-pathogenic variant detected/)
-              genocolorectal.add_variant_class(6) #Ad-hoc variant path class for when we know it is class1/2 but can't distinguish.
             else
               @logger.debug 'NO VARIANTPATHCLASS DETECTED'
+              check_for_non_path_variant(genocolorectal, record)
             end
           end
 
+        def check_for_non_path_variant(genocolorectal, record)
+          if /non-pathogenic\svariant\sdetected/i.match(record.raw_fields['teststatus'])
+            genocolorectal.add_variant_class(6) #Ad-hoc variant path class for when we know it is class1/2 but can't distinguish.
+          end 
+        end 
+       
           def process_teststatus(genocolorectal, record)
             teststatus = record.raw_fields['teststatus'] unless record.raw_fields['teststatus'].nil?
             case teststatus
             when /NO PATHOGENIC (VARIANT|DEL\/DUP) IDENTIFIED/ || /No mutation detected/
               genocolorectal.add_status(1)
-            when /non-pathogenic variant detected/
+            when /non-pathogenic\svariant\sdetected/i
               genocolorectal.add_status(10)
             when /Fail/i
               genocolorectal.add_status(9)


### PR DESCRIPTION
**What?**
Adding in functionality to use the test status 10 value when recording the status of variant results. 

**Why?**
The importer for Royal Marsden is not currently the test status 10 value to record abnormal, non pathogenic variants so requires updating 

**How?**


**Testing?**
