### PR TITLE
Added another rule for missing SRI

### DIFF
--- a/lib/import/colorectal/providers/leeds/leeds_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/leeds/leeds_handler_colorectal.rb
@@ -369,6 +369,8 @@ module Import
               %w[MLH1 MSH2 MSH6 PMS2 EPCAM]
             when /r211/
               %w[APC BMPR1A EPCAM GREM1 MLH1 MSH2 MSH6 MUTYH NTHL1 PMS2 POLD1 POLE PTEN SMAD4 STK11]
+            when /confirmation/
+              @indicationcategory == '11450' ? %w[MLH1] : []
             else
               []
             end

--- a/lib/import/colorectal/providers/leeds/leeds_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/leeds/leeds_handler_colorectal.rb
@@ -370,7 +370,16 @@ module Import
             when /r211/
               %w[APC BMPR1A EPCAM GREM1 MLH1 MSH2 MSH6 MUTYH NTHL1 PMS2 POLD1 POLE PTEN SMAD4 STK11]
             when /confirmation/
-              @indicationcategory == '11450' ? %w[MLH1] : []
+              genes_for_confirmation_mtype
+            else
+              []
+            end
+          end
+
+          def genes_for_confirmation_mtype
+            if @indicationcategory == '11450' && @geno == 'mlpa del confirmation +ve' &&
+               @report.match(/familial\spathogenic\sdeletion\sof\sexons\s16-19/ix)
+              %w[MLH1]
             else
               []
             end


### PR DESCRIPTION
## What?

We were waiting to hear from lab for gene to be confirmed for one of the missing SRIs from Leeds,(detected during CASREF Refresh) so now it's added in this PR.

## Why?
Fiona wanted to be sure if the combination of moleculartestingtype and indicationcategory is meant for MLH1 and asked lab to confirm. Today email has been answered by Rachel from Leeds.

## How?
Rules have been updated to include above combination to determine gene.

## Testing?
Have run locally and now query return expected result of 3845 -

```
select count(distinct(servicereportidentifier)) from restricted_results_all where original_filename like '%MMR%';
 count 
-------
  3845
(1 row)
```

## Anything else ?
For reference email dated 22 July 2024 from Fiona "FW: Leeds CRC SRIs" can be seen.