### PR TITLE
Allow ADFS login for accounts without a SAML emailaddress

### DIFF
--- a/config/attribute-map.yml
+++ b/config/attribute-map.yml
@@ -11,6 +11,10 @@ test:
 production:
   objectGuid: object_guid
   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn": upn
-  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress": email
+  # The PHE ADFS server now includes blank email addresses for (some?) ex @phe staff.
+  # As an alternative to the below, we could write a saml_update_resource_hook that
+  # ignored blank email values, cf.
+  # https://github.com/apokalipto/devise_saml_authenticatable/tree/refs/heads/1.x-maintenance
+  # "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress": email
   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname": first_name
   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname": last_name

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -273,7 +273,12 @@ Devise.setup do |config|
   config.saml_create_user = true
 
   # Update the attributes of the user after a successful login. (Default is false)
-  config.saml_update_user = true
+  # config.saml_update_user = true
+  # The PHE ADFS server now includes blank email addresses for (some?) ex @phe staff.
+  # As an alternative to the below, we could write a saml_update_resource_hook that
+  # ignored blank email values, cf.
+  # https://github.com/apokalipto/devise_saml_authenticatable/tree/refs/heads/1.x-maintenance
+  config.saml_update_user = false
 
   # Set the default user key. The user will be looked up by this key. Make
   # sure that the Authentication Response includes the attribute.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -273,12 +273,7 @@ Devise.setup do |config|
   config.saml_create_user = true
 
   # Update the attributes of the user after a successful login. (Default is false)
-  # config.saml_update_user = true
-  # The PHE ADFS server now includes blank email addresses for (some?) ex @phe staff.
-  # As an alternative to the below, we could write a saml_update_resource_hook that
-  # ignored blank email values, cf.
-  # https://github.com/apokalipto/devise_saml_authenticatable/tree/refs/heads/1.x-maintenance
-  config.saml_update_user = false
+  config.saml_update_user = true
 
   # Set the default user key. The user will be looked up by this key. Make
   # sure that the Authentication Response includes the attribute.


### PR DESCRIPTION
The PHE ADFS server now includes blank email addresses for (some?) ex @phe staff. This PR ignores the `emailaddress` SAML field: the `User` object being updated on login, which was causing an error when a blank email address was being applied. Instead, users are identified by the `upn` (which contains their email address).

I've deployed this to the beta site before review, to confirm that it works.