### PR TITLE
Fixed bug for missing organisational_testresult

### DIFF
--- a/lib/import/brca/providers/bristol/bristol_handler.rb
+++ b/lib/import/brca/providers/bristol/bristol_handler.rb
@@ -32,7 +32,6 @@ module Import
 
           def process_positive_record(genotype, positive_gene, record, genotypes)
             process_cdna_change(genotype, record)
-            genotype.add_gene_location(record.mapped_fields['codingdnasequencechange'])
             add_protein_impact(genotype, record)
             genotype.add_variant_class(record.mapped_fields['variantpathclass'])
             process_genomic_change(genotype, record)

--- a/lib/import/brca/providers/bristol/bristol_handler.rb
+++ b/lib/import/brca/providers/bristol/bristol_handler.rb
@@ -1,5 +1,3 @@
-require 'possibly'
-require 'pry'
 module Import
   module Brca
     module Providers
@@ -8,43 +6,39 @@ module Import
         class BristolHandler < Import::Germline::ProviderHandler
           include Import::Helpers::Brca::Providers::Rvj::RvjConstants
 
-          # rubocop:disable  Metrics/MethodLength
-          # rubocop:disable  Metrics/AbcSize
           def process_fields(record)
             genotype = Import::Brca::Core::GenotypeBrca.new(record)
             genotype.add_passthrough_fields(record.mapped_fields,
                                             record.raw_fields,
                                             PASS_THROUGH_FIELDS)
-            process_cdna_change(genotype, record)
-            add_protein_impact(genotype, record)
             add_organisationcode_testresult(genotype)
-            genotype.add_gene_location(record.mapped_fields['codingdnasequencechange'])
-            add_protein_impact(genotype, record)
-            genotype.add_variant_class(record.mapped_fields['variantpathclass'])
-            genotype.add_received_date(record.raw_fields['received date'])
-            process_genomic_change(genotype, record)
             genotype.add_test_scope(:full_screen)
-            process_test_status(genotype, record)
+            genotype.add_received_date(record.raw_fields['received date'])
             genotype.add_method('ngs')
             res = process_gene(genotype, record)
             res&.each { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
           end
-          # rubocop:enable  Metrics/MethodLength
-          # rubocop:enable  Metrics/AbcSize
 
           def add_organisationcode_testresult(genotype)
             genotype.attribute_map['organisationcode_testresult'] = '698V0'
           end
 
-          def process_negative_record(record, negative_gene, genotypes)
-            duplicated_genotype = Import::Brca::Core::GenotypeBrca.new(record)
+          def process_negative_record(genotype, negative_gene, genotypes)
+            duplicated_genotype = genotype.dup
             duplicated_genotype.add_gene(negative_gene.join)
             duplicated_genotype.add_status(1)
-            duplicated_genotype.add_test_scope(:full_screen)
-            duplicated_genotype.add_passthrough_fields(record.mapped_fields,
-                                                       record.raw_fields,
-                                                       PASS_THROUGH_FIELDS)
             genotypes.append(duplicated_genotype)
+          end
+
+          def process_positive_record(genotype, positive_gene, record, genotypes)
+            process_cdna_change(genotype, record)
+            genotype.add_gene_location(record.mapped_fields['codingdnasequencechange'])
+            add_protein_impact(genotype, record)
+            genotype.add_variant_class(record.mapped_fields['variantpathclass'])
+            process_genomic_change(genotype, record)
+            process_test_status(genotype, record)
+            genotype.add_gene(positive_gene)
+            genotypes.append(genotype)
           end
 
           def process_gene(genotype, record)
@@ -53,21 +47,16 @@ module Import
             positive_raw_gene = record.raw_fields['gene']
             genotypes = []
             negative_gene = %w[BRCA1 BRCA2] - [positive_raw_gene]
-            process_negative_record(record, negative_gene, genotypes)
-            genotype.add_gene(positive_raw_gene)
-            genotypes.append(genotype)
+            process_negative_record(genotype, negative_gene, genotypes)
+            process_positive_record(genotype, positive_raw_gene, record, genotypes)
           end
 
-          # rubocop:disable Style/GuardClause
           def process_test_status(genotype, record)
             return if record.raw_fields['variantpathclass'].nil?
 
             varpathclass_field = record.raw_fields['variantpathclass']
-            if TESTSTATUS_MAP[varpathclass_field].present?
-              genotype.add_status(TESTSTATUS_MAP[varpathclass_field])
-            end
+            genotype.add_status(TESTSTATUS_MAP[varpathclass_field]) if TESTSTATUS_MAP[varpathclass_field].present?
           end
-          # rubocop:enable Style/GuardClause
 
           def process_cdna_change(genotype, record)
             case record.mapped_fields['codingdnasequencechange']


### PR DESCRIPTION
## What?
Some of the Bristol records were missing ORGANISATIONCODE_TESTRESULT .  More details on Jira #2056

## Why?
Genotype duplication logic was wrong and rather duplicating a new genotype, it was being created from raw record and hence was loosing on the properties already set.

## How?
Logic has been rightly applied for duplicating genotype and also code has been restructured.

## Test? 

```select * from molecular_data where organisationcode_testresult is null;  ``` gives 0 rows now.